### PR TITLE
appender: Add FailedClient and FailedServer stats

### DIFF
--- a/appender_test.go
+++ b/appender_test.go
@@ -102,6 +102,8 @@ loop:
 		Active:                0,
 		BulkRequests:          1,
 		Failed:                2,
+		FailedClient:          1,
+		FailedServer:          1,
 		Indexed:               N - 2,
 		TooManyRequests:       1,
 		AvailableBulkRequests: 10,


### PR DESCRIPTION
Updates the appender to record the number of requests that failed due to a client error (4xx), or a server error (5xx). Introduces two new fields `Stats.FailedClient` and `Stats.FailedServer`.