### PR TITLE
stats: Exclude TooMany from FailedClient

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -580,7 +580,7 @@ type Stats struct {
 	BulkRequests int64
 
 	// Failed holds the number of indexing operations that failed. It includes
-	// All failures.
+	// all failures.
 	Failed int64
 
 	// FailedClient holds the number of indexing operations that failed with a

--- a/appender.go
+++ b/appender.go
@@ -275,10 +275,11 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *bulkIndexer) error {
 			if info.Error.Type != "" || info.Status > 201 {
 				docsFailed++
 				if info.Status >= 400 && info.Status < 500 {
-					clientFailed++
-				}
-				if info.Status == http.StatusTooManyRequests {
-					tooManyRequests++
+					if info.Status == http.StatusTooManyRequests {
+						tooManyRequests++
+					} else {
+						clientFailed++
+					}
 				}
 				if info.Status >= 500 {
 					serverFailed++
@@ -578,11 +579,12 @@ type Stats struct {
 	// BulkRequests holds the number of bulk requests completed.
 	BulkRequests int64
 
-	// Failed holds the number of indexing operations that failed.
+	// Failed holds the number of indexing operations that failed. It includes
+	// All failures.
 	Failed int64
 
 	// FailedClient holds the number of indexing operations that failed with a
-	// status_code >= 400 < 500.
+	// status_code >= 400 < 500, but not 429.
 	FailedClient int64
 
 	// FailedClient holds the number of indexing operations that failed with a

--- a/appender_test.go
+++ b/appender_test.go
@@ -51,12 +51,15 @@ func TestAppender(t *testing.T) {
 		// "too many requests". These will be recorded as failures in indexing
 		// stats.
 		for i := range result.Items {
-			if i >= 2 {
+			if i > 2 {
 				break
 			}
 			status := http.StatusInternalServerError
-			if i == 1 {
+			switch i {
+			case 1:
 				status = http.StatusTooManyRequests
+			case 2:
+				status = http.StatusUnauthorized
 			}
 			for action, item := range result.Items[i] {
 				item.Status = status
@@ -97,14 +100,15 @@ loop:
 	err = indexer.Close(context.Background())
 	require.NoError(t, err)
 	stats := indexer.Stats()
+	failed := int64(3)
 	assert.Equal(t, docappender.Stats{
 		Added:                 N,
 		Active:                0,
 		BulkRequests:          1,
-		Failed:                2,
+		Failed:                failed,
 		FailedClient:          1,
 		FailedServer:          1,
-		Indexed:               N - 2,
+		Indexed:               N - failed,
 		TooManyRequests:       1,
 		AvailableBulkRequests: 10,
 		BytesTotal:            bytesTotal,


### PR DESCRIPTION
For `TooMany`, `FailedClient` and `FailedServer` to equal `Failed`.