### PR TITLE
appender: include index name in index failure

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -288,8 +288,8 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *bulkIndexer) error {
 				// in the error message so we can observe different
 				// error types/reasons when logging is rate limited.
 				logger.Error(fmt.Sprintf(
-					"failed to index document (%s): %s",
-					info.Error.Type, info.Error.Reason,
+					"failed to index document in '%s' (%s): %s",
+					info.Index, info.Error.Type, info.Error.Reason,
 				))
 			} else {
 				docsIndexed++

--- a/appender_test.go
+++ b/appender_test.go
@@ -353,6 +353,7 @@ func TestAppenderIndexFailedLogging(t *testing.T) {
 		_, result := docappendertest.DecodeBulkRequest(r)
 		for i, item := range result.Items {
 			itemResp := item["create"]
+			itemResp.Index = "an_index"
 			itemResp.Error.Type = "error_type"
 			if i%2 == 0 {
 				itemResp.Error.Reason = "error_reason_even"
@@ -382,10 +383,10 @@ func TestAppenderIndexFailedLogging(t *testing.T) {
 
 	entries := observed.FilterMessageSnippet("failed to index document").TakeAll()
 	require.Len(t, entries, N)
-	assert.Equal(t, "failed to index document (error_type): error_reason_even", entries[0].Message)
-	assert.Equal(t, "failed to index document (error_type): error_reason_odd", entries[1].Message)
-	assert.Equal(t, "failed to index document (error_type): error_reason_even", entries[2].Message)
-	assert.Equal(t, "failed to index document (error_type): error_reason_odd", entries[3].Message)
+	assert.Equal(t, "failed to index document in 'an_index' (error_type): error_reason_even", entries[0].Message)
+	assert.Equal(t, "failed to index document in 'an_index' (error_type): error_reason_odd", entries[1].Message)
+	assert.Equal(t, "failed to index document in 'an_index' (error_type): error_reason_even", entries[2].Message)
+	assert.Equal(t, "failed to index document in 'an_index' (error_type): error_reason_odd", entries[3].Message)
 }
 
 func TestAppenderCloseFlushContext(t *testing.T) {


### PR DESCRIPTION
Include the index name in the indexing failure, making it easier to tell which index may be returning indexing failures.