### PR TITLE
perf: use a minimal bulk response struct to decode body

### DIFF
--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -65,7 +65,6 @@ type MinimalBulkIndexerResponse struct {
 type BulkIndexerResponseItem struct {
 	Index  string `json:"_index"`
 	Status int    `json:"status"`
-	SeqNo  int64  `json:"_seq_no"`
 
 	Error struct {
 		Type   string `json:"type"`

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -57,7 +57,8 @@ type bulkIndexer struct {
 	resp         MinimalBulkIndexerResponse
 }
 
-type MinimalBulkIndexerResponse struct {
+// BulkIndexerResponse represents a minimal subset of the Elasticsearch _bulk API response.
+type BulkIndexerResponse struct {
 	Items []map[string]BulkIndexerResponseItem `json:"items,omitempty"`
 }
 

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -57,8 +57,8 @@ type bulkIndexer struct {
 	resp         MinimalBulkIndexerResponse
 }
 
-// BulkIndexerResponse represents a minimal subset of the Elasticsearch _bulk API response.
-type BulkIndexerResponse struct {
+// MinimalBulkIndexerResponse represents a minimal subset of the Elasticsearch _bulk API response.
+type MinimalBulkIndexerResponse struct {
 	Items []map[string]BulkIndexerResponseItem `json:"items,omitempty"`
 }
 


### PR DESCRIPTION
Fix https://github.com/elastic/go-docappender/pull/33#pullrequestreview-1489540847

I updated the code locally but didn't push the changes :sweat: 

Sorry @axw 