### PR TITLE
Rename transaction, and remove global variable

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -290,6 +290,10 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *bulkIndexer) error {
 					"failed to index document in '%s' (%s): %s",
 					info.Index, info.Error.Type, info.Error.Reason,
 				))
+
+				if a.tracingEnabled() {
+					apm.CaptureError(ctx, errors.New(info.Error.Reason)).Send()
+				}
 			} else {
 				docsIndexed++
 			}

--- a/appender_test.go
+++ b/appender_test.go
@@ -876,7 +876,7 @@ func testAppenderTracing(t *testing.T, statusCode int, expectedOutcome string) {
 
 	assert.Equal(t, expectedOutcome, payloads.Transactions[0].Outcome)
 	assert.Equal(t, "output", payloads.Transactions[0].Type)
-	assert.Equal(t, "flush", payloads.Transactions[0].Name)
+	assert.Equal(t, "docappender.flush", payloads.Transactions[0].Name)
 	assert.Equal(t, "Elasticsearch: POST _bulk", payloads.Spans[0].Name)
 	assert.Equal(t, "db", payloads.Spans[0].Type)
 	assert.Equal(t, "elasticsearch", payloads.Spans[0].Subtype)


### PR DESCRIPTION
The `flush` transaction is quite obscure. We could be flushing many things.
So this renamed it to `docappender.flush`, which should be more meaningful.

While I was there, I also removed the global variable, and added error reporting for failed documents.