### PR TITLE
feat: support otel metrics for existing metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,8 @@ jobs:
     - run: go mod tidy -v
     - uses: dominikh/staticcheck-action@v1.3.0
       with:
-        version: "2022.1.3"
+        version: "2023.1.3"
         install-go: false
-        cache-key: 1.20
     - name: Verify repo is up-to-date
       run: |
         if [ -n "$(git status --porcelain)" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
-        cache: true
+        cache: false
     - run: make update-licenses
     - run: go run golang.org/x/tools/cmd/goimports@v0.3.0 -w .
     - run: go mod tidy -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
-        cache: false
+        cache: true
     - run: make update-licenses
     - run: go run golang.org/x/tools/cmd/goimports@v0.3.0 -w .
     - run: go mod tidy -v
@@ -20,6 +20,7 @@ jobs:
       with:
         version: "2022.1.3"
         install-go: false
+        cache-key: 1.20
     - name: Verify repo is up-to-date
       run: |
         if [ -n "$(git status --porcelain)" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - run: go mod tidy -v
     - uses: dominikh/staticcheck-action@v1.3.0
       with:
-        version: "2022.1.1"
+        version: "2022.1.3"
         install-go: false
     - name: Verify repo is up-to-date
       run: |

--- a/appender.go
+++ b/appender.go
@@ -137,14 +137,14 @@ func New(client *elasticsearch.Client, cfg Config) (*Appender, error) {
 		cfg.Logger = zap.NewNop()
 	}
 	indexer := &Appender{
-		availableBulkRequests: int64(len(available)),
-		config:                cfg,
-		available:             available,
-		closed:                make(chan struct{}),
-		bulkItems:             make(chan bulkIndexerItem, cfg.DocumentBufferSize),
-		metrics:               ms,
-		telemetryAttrs:        attribute.NewSet(cfg.MetricAttributes...),
+		config:         cfg,
+		available:      available,
+		closed:         make(chan struct{}),
+		bulkItems:      make(chan bulkIndexerItem, cfg.DocumentBufferSize),
+		metrics:        ms,
+		telemetryAttrs: attribute.NewSet(cfg.MetricAttributes...),
 	}
+	indexer.addCount(int64(len(available)), &indexer.availableBulkRequests, ms.availableBulkRequests)
 
 	// We create a cancellable context for the errgroup.Group for unblocking
 	// flushes when Close returns. We intentionally do not use errgroup.WithContext,

--- a/appender.go
+++ b/appender.go
@@ -82,7 +82,7 @@ type Appender struct {
 	errgroupContext       context.Context
 	cancelErrgroupContext context.CancelFunc
 	telemetryAttrs        attribute.Set
-	metrics               Metrics
+	metrics               metrics
 	mu                    sync.Mutex
 	closed                chan struct{}
 }
@@ -142,7 +142,7 @@ func New(client *elasticsearch.Client, cfg Config) (*Appender, error) {
 		closed:         make(chan struct{}),
 		bulkItems:      make(chan bulkIndexerItem, cfg.DocumentBufferSize),
 		metrics:        ms,
-		telemetryAttrs: attribute.NewSet(cfg.MetricAttributes...),
+		telemetryAttrs: cfg.MetricAttributes,
 	}
 	indexer.addCount(int64(len(available)), &indexer.availableBulkRequests, ms.availableBulkRequests)
 
@@ -244,7 +244,7 @@ func (a *Appender) addCount(delta int64, lm *int64, m metric.Int64Counter) {
 	// legacy metric
 	atomic.AddInt64(lm, delta)
 
-	attrs := metric.WithAttributes(a.config.MetricAttributes...)
+	attrs := metric.WithAttributeSet(a.config.MetricAttributes)
 	m.Add(context.Background(), delta, attrs)
 }
 

--- a/appender.go
+++ b/appender.go
@@ -32,7 +32,6 @@ import (
 	"github.com/elastic/go-elasticsearch/v8"
 	"go.elastic.co/apm/module/apmzap/v2"
 	"go.elastic.co/apm/v2"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
@@ -60,6 +59,7 @@ var (
 // Up to `config.MaxRequests` bulk requests may be flushing/active concurrently, to allow the
 // server to make progress encoding while Elasticsearch is busy servicing flushed bulk requests.
 type Appender struct {
+	// legacy metrics for Stats()
 	bulkRequests          int64
 	docsAdded             int64
 	docsActive            int64
@@ -81,12 +81,10 @@ type Appender struct {
 	errgroup              errgroup.Group
 	errgroupContext       context.Context
 	cancelErrgroupContext context.CancelFunc
-	bufferDuration        metric.Float64Histogram
-	flushDuration         metric.Float64Histogram
 	telemetryAttrs        attribute.Set
-
-	mu     sync.Mutex
-	closed chan struct{}
+	metrics               Metrics
+	mu                    sync.Mutex
+	closed                chan struct{}
 }
 
 // New returns a new Appender that indexes documents into Elasticsearch.
@@ -126,31 +124,10 @@ func New(client *elasticsearch.Client, cfg Config) (*Appender, error) {
 			cfg.Scaling.IdleInterval = 30 * time.Second
 		}
 	}
-	if cfg.MeterProvider == nil {
-		cfg.MeterProvider = otel.GetMeterProvider()
-	}
-	meter := cfg.MeterProvider.Meter("github.com/elastic/go-docappender")
-	bufDuration, err := meter.Float64Histogram("elasticsearch.buffer.latency",
-		metric.WithUnit("s"),
-		metric.WithDescription(
-			"The amount of time a document was buffered for, in seconds.",
-		),
-	)
+
+	ms, err := newMetrics(cfg)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"failed creating elasticsearch.buffer.latency metric: %w", err,
-		)
-	}
-	flushDuration, err := meter.Float64Histogram("elasticsearch.flushed.latency",
-		metric.WithUnit("s"),
-		metric.WithDescription(
-			"The amount of time a _bulk request took, in seconds.",
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"failed creating elasticsearch.flushed.latency metric: %w", err,
-		)
+		return nil, err
 	}
 	available := make(chan *bulkIndexer, cfg.MaxRequests)
 	for i := 0; i < cfg.MaxRequests; i++ {
@@ -165,8 +142,7 @@ func New(client *elasticsearch.Client, cfg Config) (*Appender, error) {
 		available:             available,
 		closed:                make(chan struct{}),
 		bulkItems:             make(chan bulkIndexerItem, cfg.DocumentBufferSize),
-		bufferDuration:        bufDuration,
-		flushDuration:         flushDuration,
+		metrics:               ms,
 		telemetryAttrs:        attribute.NewSet(cfg.MetricAttributes...),
 	}
 
@@ -259,9 +235,17 @@ func (a *Appender) Add(ctx context.Context, index string, document io.Reader) er
 		return ErrClosed
 	case a.bulkItems <- item:
 	}
-	atomic.AddInt64(&a.docsAdded, 1)
-	atomic.AddInt64(&a.docsActive, 1)
+	a.addCount(1, &a.docsAdded, a.metrics.docsAdded)
+	a.addCount(1, &a.docsActive, a.metrics.docsActive)
 	return nil
+}
+
+func (a *Appender) addCount(delta int64, lm *int64, m metric.Int64Counter) {
+	// legacy metric
+	atomic.AddInt64(lm, delta)
+
+	attrs := metric.WithAttributes(a.config.MetricAttributes...)
+	m.Add(context.Background(), delta, attrs)
 }
 
 func (a *Appender) flush(ctx context.Context, bulkIndexer *bulkIndexer) error {
@@ -269,8 +253,8 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *bulkIndexer) error {
 	if n == 0 {
 		return nil
 	}
-	defer atomic.AddInt64(&a.docsActive, -int64(n))
-	defer atomic.AddInt64(&a.bulkRequests, 1)
+	defer a.addCount(-int64(n), &a.docsActive, a.metrics.docsActive)
+	defer a.addCount(1, &a.bulkRequests, a.metrics.bulkRequests)
 
 	logger := a.config.Logger
 	if a.tracingEnabled() {
@@ -288,10 +272,10 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *bulkIndexer) error {
 	// Record the bulkIndexer buffer's length as the bytesTotal metric after
 	// the request has been flushed.
 	if flushed := bulkIndexer.BytesFlushed(); flushed > 0 {
-		atomic.AddInt64(&a.bytesTotal, int64(flushed))
+		a.addCount(int64(flushed), &a.bytesTotal, a.metrics.bytesTotal)
 	}
 	if err != nil {
-		atomic.AddInt64(&a.docsFailed, int64(n))
+		a.addCount(int64(n), &a.docsFailed, a.metrics.docsFailed)
 		logger.Error("bulk indexing request failed", zap.Error(err))
 		if a.tracingEnabled() {
 			apm.CaptureError(ctx, err).Send()
@@ -300,7 +284,7 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *bulkIndexer) error {
 		var errTooMany errorTooManyRequests
 		// 429 may be returned as errors from the bulk indexer.
 		if errors.As(err, &errTooMany) {
-			atomic.AddInt64(&a.tooManyRequests, int64(n))
+			a.addCount(int64(n), &a.tooManyRequests, a.metrics.tooManyRequests)
 		}
 		return err
 	}
@@ -335,19 +319,19 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *bulkIndexer) error {
 		}
 	}
 	if docsFailed > 0 {
-		atomic.AddInt64(&a.docsFailed, docsFailed)
+		a.addCount(docsFailed, &a.docsFailed, a.metrics.docsFailed)
 	}
 	if docsIndexed > 0 {
-		atomic.AddInt64(&a.docsIndexed, docsIndexed)
+		a.addCount(docsIndexed, &a.docsIndexed, a.metrics.docsIndexed)
 	}
 	if tooManyRequests > 0 {
-		atomic.AddInt64(&a.tooManyRequests, tooManyRequests)
+		a.addCount(tooManyRequests, &a.tooManyRequests, a.metrics.tooManyRequests)
 	}
 	if clientFailed > 0 {
-		atomic.AddInt64(&a.docsFailedClient, clientFailed)
+		a.addCount(clientFailed, &a.docsFailedClient, a.metrics.docsFailedClient)
 	}
 	if serverFailed > 0 {
-		atomic.AddInt64(&a.docsFailedServer, serverFailed)
+		a.addCount(serverFailed, &a.docsFailedServer, a.metrics.docsFailedServer)
 	}
 	logger.Debug(
 		"bulk request completed",
@@ -379,7 +363,7 @@ func (a *Appender) runActiveIndexer() {
 			// It doesn't account for the time spent in the buffered channel.
 			firstDocTS = time.Now()
 			active = <-a.available
-			atomic.AddInt64(&a.availableBulkRequests, -1)
+			a.addCount(-1, &a.availableBulkRequests, a.metrics.availableBulkRequests)
 			flushTimer.Reset(a.config.FlushInterval)
 		}
 		if err := active.add(item); err != nil {
@@ -442,13 +426,13 @@ func (a *Appender) runActiveIndexer() {
 				})
 				indexer.Reset()
 				a.available <- indexer
-				atomic.AddInt64(&a.availableBulkRequests, 1)
-				a.flushDuration.Record(context.Background(), took.Seconds(),
+				a.addCount(1, &a.availableBulkRequests, a.metrics.availableBulkRequests)
+				a.metrics.flushDuration.Record(context.Background(), took.Seconds(),
 					attrs,
 				)
 				return err
 			})
-			a.bufferDuration.Record(context.Background(),
+			a.metrics.bufferDuration.Record(context.Background(),
 				time.Since(firstDocTS).Seconds(), attrs,
 			)
 		}
@@ -458,11 +442,11 @@ func (a *Appender) runActiveIndexer() {
 		now := time.Now()
 		info := a.scalingInformation()
 		if a.maybeScaleDown(now, info, &timedFlush) {
-			atomic.AddInt64(&a.activeDestroyed, 1)
+			a.addCount(1, &a.activeDestroyed, a.metrics.activeDestroyed)
 			return
 		}
 		if a.maybeScaleUp(now, info, &fullFlush) {
-			atomic.AddInt64(&a.activeCreated, 1)
+			a.addCount(1, &a.activeCreated, a.metrics.activeCreated)
 			a.errgroup.Go(func() error {
 				a.runActiveIndexer()
 				return nil

--- a/appender_test.go
+++ b/appender_test.go
@@ -179,7 +179,7 @@ loop:
 			unexpectedMetrics = append(unexpectedMetrics, metric.Name)
 		}
 	}
-	assert.Equal(t, []string{}, unexpectedMetrics)
+	assert.Empty(t, unexpectedMetrics)
 	assert.Equal(t, 10, asserted)
 }
 

--- a/appender_test.go
+++ b/appender_test.go
@@ -145,6 +145,8 @@ loop:
 			assert.Equal(t, attrs, dp.Attributes)
 		}
 	}
+	// check the set of names and then check the counter or histogram
+	unexpectedMetrics := []string{}
 	for _, metric := range rm.ScopeMetrics[0].Metrics {
 		switch metric.Name {
 		case "elasticsearch.events.count":
@@ -167,9 +169,17 @@ loop:
 			assertCounter(metric, stats.AvailableBulkRequests, indexerAttrs)
 		case "elasticsearch.flushed.bytes":
 			assertCounter(metric, stats.BytesTotal, indexerAttrs)
+		case "elasticsearch.buffer.latency":
+			// expect this metric name but no assertions done
+			// as it's histogram and it's checked elsewhere
+		case "elasticsearch.flushed.latency":
+			// expect this metric name but no assertions done
+			// as it's histogram and it's checked elsewhere
+		default:
+			unexpectedMetrics = append(unexpectedMetrics, metric.Name)
 		}
 	}
-	assert.Equal(t, make([]string, 0), unexpectedMetrics)
+	assert.Equal(t, []string{}, unexpectedMetrics)
 	assert.Equal(t, 10, asserted)
 }
 

--- a/config.go
+++ b/config.go
@@ -86,7 +86,7 @@ type Config struct {
 
 	// MetricAttributes holds any extra attributes to set in the recorded
 	// metrics.
-	MetricAttributes []attribute.KeyValue
+	MetricAttributes attribute.Set
 }
 
 // ScalingConfig holds the docappender autoscaling configuration.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/go-docappender
 
-go 1.19
+go 1.20
 
 require (
 	github.com/elastic/go-elasticsearch/v8 v8.9.0

--- a/metric.go
+++ b/metric.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package docappender
 
 import (

--- a/metric.go
+++ b/metric.go
@@ -1,0 +1,179 @@
+package docappender
+
+import (
+	"errors"
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type Metrics struct {
+	bufferDuration metric.Float64Histogram
+	flushDuration  metric.Float64Histogram
+
+	bulkRequests          metric.Int64Counter
+	docsAdded             metric.Int64Counter
+	docsActive            metric.Int64Counter
+	docsFailed            metric.Int64Counter
+	docsFailedClient      metric.Int64Counter
+	docsFailedServer      metric.Int64Counter
+	docsIndexed           metric.Int64Counter
+	tooManyRequests       metric.Int64Counter
+	bytesTotal            metric.Int64Counter
+	availableBulkRequests metric.Int64Counter
+	activeCreated         metric.Int64Counter
+	activeDestroyed       metric.Int64Counter
+}
+
+const (
+	METRIC_NAME_BUFFER_DURATION    = "elasticsearch.buffer.latency"
+	METRIC_NAME_FLUSH_DURATION     = "elasticsearch.flushed.latency"
+	METRIC_NAME_BULK_REQUESTS      = "elasticsearch.bulk_requests.count"
+	METRIC_NAME_DOCS_ADDED         = "elasticsearch.events.count"
+	METRIC_NAME_DOCS_ACTIVE        = "elasticsearch.events.queued"
+	METRIC_NAME_DOCS_FAILED        = "elasticsearch.failed.count"
+	METRIC_NAME_DOCS_FAILED_CLIENT = "elasticsearch.failed.client"
+	METRIC_NAME_DOCS_FAILED_SERVER = "elasticsearch.failed.server"
+	METRIC_NAME_DOCS_INDEXED       = "elasticsearch.events.processed"
+	METRIC_NAME_TOO_MANY_REQ       = "elasticsearch.failed.too_many_reqs"
+	METRIC_NAME_BYTES_TOTAL        = "elasticsearch.flushed.bytes"
+	METRIC_NAME_AVAILABLE_BULK_REQ = "elasticsearch.bulk_requests.available"
+	METRIC_NAME_ACTIVE_CREATED     = "elasticsearch.indexer.created"
+	METRIC_NAME_ACTIVE_DESTROYED   = "elasticsearch.indexer.destroyed"
+)
+
+func newMetrics(cfg Config) (Metrics, error) {
+	if cfg.MeterProvider == nil {
+		cfg.MeterProvider = otel.GetMeterProvider()
+	}
+	meter := cfg.MeterProvider.Meter("github.com/elastic/go-docappender")
+
+	var errs []error
+	ms := Metrics{
+		bufferDuration: newFloat64Histogram(
+			meter,
+			METRIC_NAME_BUFFER_DURATION,
+			"The amount of time a document was buffered for, in seconds.",
+			"s",
+			&errs,
+		),
+		flushDuration: newFloat64Histogram(
+			meter,
+			METRIC_NAME_FLUSH_DURATION,
+			"The amount of time a _bulk request took, in seconds.",
+			"s",
+			&errs,
+		),
+		bulkRequests: newInt64Counter(
+			meter,
+			METRIC_NAME_BULK_REQUESTS,
+			"The number of bulk requests completed.",
+			"1",
+			&errs),
+		docsAdded: newInt64Counter(
+			meter,
+			METRIC_NAME_DOCS_ADDED,
+			"the total number of items added to the indexer.",
+			"1",
+			&errs),
+		docsActive: newInt64Counter(
+			meter,
+			METRIC_NAME_DOCS_ACTIVE,
+			"the number of active items waiting in the indexer's queue.",
+			"1",
+			&errs),
+		docsFailed: newInt64Counter(
+			meter,
+			METRIC_NAME_DOCS_FAILED,
+			"The number of indexing operations that failed",
+			"1",
+			&errs),
+		docsFailedClient: newInt64Counter(
+			meter,
+			METRIC_NAME_DOCS_FAILED_CLIENT,
+			"The number of docs failed to get indexed with client error(status_code >= 400 < 500, but not 429).",
+			"1",
+			&errs),
+		docsFailedServer: newInt64Counter(
+			meter,
+			METRIC_NAME_DOCS_FAILED_SERVER,
+			"The number of docs failed to get indexed with server error(status_code >= 500).",
+			"1",
+			&errs),
+		docsIndexed: newInt64Counter(
+			meter,
+			METRIC_NAME_DOCS_INDEXED,
+			"The number of docs indexed successfully.",
+			"1",
+			&errs),
+		tooManyRequests: newInt64Counter(
+			meter,
+			METRIC_NAME_TOO_MANY_REQ,
+			"The number of 429 errors returned from the bulk indexer due to too many requests.",
+			"1",
+			&errs),
+		bytesTotal: newInt64Counter(
+			meter,
+			METRIC_NAME_BYTES_TOTAL,
+			"The total number of bytes written to the request body",
+			"by",
+			&errs),
+		availableBulkRequests: newInt64Counter(
+			meter,
+			METRIC_NAME_AVAILABLE_BULK_REQ,
+			"The number of bulk indexers available for making bulk index requests.",
+			"1",
+			&errs),
+		activeCreated: newInt64Counter(
+			meter,
+			METRIC_NAME_ACTIVE_CREATED,
+			"The number of active bulk indexers that are concurrently processing batches.",
+			"1",
+			&errs),
+		activeDestroyed: newInt64Counter(
+			meter,
+			METRIC_NAME_ACTIVE_DESTROYED,
+			"Tthe number of times an active indexer was destroyed.",
+			"1",
+			&errs),
+	}
+
+	if len(errs) > 0 {
+		return ms, fmt.Errorf(
+			"failed creating metrics: %w", errors.Join(errs...),
+		)
+	}
+
+	return ms, nil
+}
+
+func newInt64Counter(meter metric.Meter, name string, description string, unit string, errs *[]error) metric.Int64Counter {
+	m, err := meter.Int64Counter(
+		name,
+		metric.WithUnit(unit),
+		metric.WithDescription(description),
+	)
+
+	if err != nil {
+		*errs = append(*errs, fmt.Errorf(
+			"failed creating %s metric: %w", name, err,
+		))
+	}
+	return m
+}
+
+func newFloat64Histogram(meter metric.Meter, name string, description string, unit string, errors *[]error) metric.Float64Histogram {
+	m, err := meter.Float64Histogram(
+		name,
+		metric.WithUnit(unit),
+		metric.WithDescription(description),
+	)
+
+	if err != nil {
+		*errors = append(*errors, fmt.Errorf(
+			"failed creating %s metric: %w", name, err,
+		))
+	}
+	return m
+}

--- a/metric.go
+++ b/metric.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-type Metrics struct {
+type metrics struct {
 	bufferDuration metric.Float64Histogram
 	flushDuration  metric.Float64Histogram
 
@@ -44,114 +44,114 @@ type Metrics struct {
 }
 
 const (
-	METRIC_NAME_BUFFER_DURATION    = "elasticsearch.buffer.latency"
-	METRIC_NAME_FLUSH_DURATION     = "elasticsearch.flushed.latency"
-	METRIC_NAME_BULK_REQUESTS      = "elasticsearch.bulk_requests.count"
-	METRIC_NAME_DOCS_ADDED         = "elasticsearch.events.count"
-	METRIC_NAME_DOCS_ACTIVE        = "elasticsearch.events.queued"
-	METRIC_NAME_DOCS_FAILED        = "elasticsearch.failed.count"
-	METRIC_NAME_DOCS_FAILED_CLIENT = "elasticsearch.failed.client"
-	METRIC_NAME_DOCS_FAILED_SERVER = "elasticsearch.failed.server"
-	METRIC_NAME_DOCS_INDEXED       = "elasticsearch.events.processed"
-	METRIC_NAME_TOO_MANY_REQ       = "elasticsearch.failed.too_many_reqs"
-	METRIC_NAME_BYTES_TOTAL        = "elasticsearch.flushed.bytes"
-	METRIC_NAME_AVAILABLE_BULK_REQ = "elasticsearch.bulk_requests.available"
-	METRIC_NAME_ACTIVE_CREATED     = "elasticsearch.indexer.created"
-	METRIC_NAME_ACTIVE_DESTROYED   = "elasticsearch.indexer.destroyed"
+	metricBufferDuration   = "elasticsearch.buffer.latency"
+	metricFlushDuration    = "elasticsearch.flushed.latency"
+	metricBulkRequests     = "elasticsearch.bulk_requests.count"
+	metricDocsAdded        = "elasticsearch.events.count"
+	metricDocsActive       = "elasticsearch.events.queued"
+	metricDocsFailed       = "elasticsearch.failed.count"
+	metricDocsFailedClient = "elasticsearch.failed.client.count"
+	metricDocsFailedServer = "elasticsearch.failed.server.count"
+	metricDocsIndexed      = "elasticsearch.events.processed"
+	metricTooManyReq       = "elasticsearch.failed.too_many_reqs"
+	metricBytesTotal       = "elasticsearch.flushed.bytes"
+	metricAvailableBulkReq = "elasticsearch.bulk_requests.available"
+	metricActiveCreated    = "elasticsearch.indexer.created"
+	metricActiveDestroyed  = "elasticsearch.indexer.destroyed"
 )
 
-func newMetrics(cfg Config) (Metrics, error) {
+func newMetrics(cfg Config) (metrics, error) {
 	if cfg.MeterProvider == nil {
 		cfg.MeterProvider = otel.GetMeterProvider()
 	}
 	meter := cfg.MeterProvider.Meter("github.com/elastic/go-docappender")
 
 	var errs []error
-	ms := Metrics{
+	ms := metrics{
 		bufferDuration: newFloat64Histogram(
 			meter,
-			METRIC_NAME_BUFFER_DURATION,
+			metricBufferDuration,
 			"The amount of time a document was buffered for, in seconds.",
 			"s",
 			&errs,
 		),
 		flushDuration: newFloat64Histogram(
 			meter,
-			METRIC_NAME_FLUSH_DURATION,
+			metricFlushDuration,
 			"The amount of time a _bulk request took, in seconds.",
 			"s",
 			&errs,
 		),
 		bulkRequests: newInt64Counter(
 			meter,
-			METRIC_NAME_BULK_REQUESTS,
+			metricBulkRequests,
 			"The number of bulk requests completed.",
 			"1",
 			&errs),
 		docsAdded: newInt64Counter(
 			meter,
-			METRIC_NAME_DOCS_ADDED,
+			metricDocsAdded,
 			"the total number of items added to the indexer.",
 			"1",
 			&errs),
 		docsActive: newInt64Counter(
 			meter,
-			METRIC_NAME_DOCS_ACTIVE,
+			metricDocsActive,
 			"the number of active items waiting in the indexer's queue.",
 			"1",
 			&errs),
 		docsFailed: newInt64Counter(
 			meter,
-			METRIC_NAME_DOCS_FAILED,
+			metricDocsFailed,
 			"The number of indexing operations that failed",
 			"1",
 			&errs),
 		docsFailedClient: newInt64Counter(
 			meter,
-			METRIC_NAME_DOCS_FAILED_CLIENT,
+			metricDocsFailedClient,
 			"The number of docs failed to get indexed with client error(status_code >= 400 < 500, but not 429).",
 			"1",
 			&errs),
 		docsFailedServer: newInt64Counter(
 			meter,
-			METRIC_NAME_DOCS_FAILED_SERVER,
+			metricDocsFailedServer,
 			"The number of docs failed to get indexed with server error(status_code >= 500).",
 			"1",
 			&errs),
 		docsIndexed: newInt64Counter(
 			meter,
-			METRIC_NAME_DOCS_INDEXED,
+			metricDocsIndexed,
 			"The number of docs indexed successfully.",
 			"1",
 			&errs),
 		tooManyRequests: newInt64Counter(
 			meter,
-			METRIC_NAME_TOO_MANY_REQ,
+			metricTooManyReq,
 			"The number of 429 errors returned from the bulk indexer due to too many requests.",
 			"1",
 			&errs),
 		bytesTotal: newInt64Counter(
 			meter,
-			METRIC_NAME_BYTES_TOTAL,
+			metricBytesTotal,
 			"The total number of bytes written to the request body",
 			"by",
 			&errs),
 		availableBulkRequests: newInt64Counter(
 			meter,
-			METRIC_NAME_AVAILABLE_BULK_REQ,
+			metricAvailableBulkReq,
 			"The number of bulk indexers available for making bulk index requests.",
 			"1",
 			&errs),
 		activeCreated: newInt64Counter(
 			meter,
-			METRIC_NAME_ACTIVE_CREATED,
-			"The number of active bulk indexers that are concurrently processing batches.",
+			metricActiveCreated,
+			"The number of active indexer creations.",
 			"1",
 			&errs),
 		activeDestroyed: newInt64Counter(
 			meter,
-			METRIC_NAME_ACTIVE_DESTROYED,
-			"Tthe number of times an active indexer was destroyed.",
+			metricActiveDestroyed,
+			"The number of times an active indexer was destroyed.",
 			"1",
 			&errs),
 	}


### PR DESCRIPTION
closes #37 

Support otel metrics for the existing metrics so it can be exported by the client

