### PR TITLE
feat: dimensional metrics for `elasticsearch.events.processed` metric

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -82,7 +82,7 @@ type Appender struct {
 	errgroupContext       context.Context
 	cancelErrgroupContext context.CancelFunc
 	telemetryAttrs        attribute.Set
-	metrics               metrics
+	metrics               *metrics
 	reg                   metric.Registration
 	mu                    sync.Mutex
 	closed                chan struct{}
@@ -175,7 +175,7 @@ func (a *Appender) Close(ctx context.Context) error {
 	case <-a.closed:
 	default:
 		close(a.closed)
-		a.reg.Unregister()
+		// a.reg.Unregister()
 		// Cancel ongoing flushes when ctx is cancelled.
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()

--- a/metric.go
+++ b/metric.go
@@ -59,7 +59,7 @@ type counterMetric struct {
 	p           *metric.Int64Counter
 }
 
-func newMetrics(cfg Config) (metrics, metric.Registration, error) {
+func newMetrics(cfg Config) (*metrics, metric.Registration, error) {
 	if cfg.MeterProvider == nil {
 		cfg.MeterProvider = otel.GetMeterProvider()
 	}
@@ -83,7 +83,7 @@ func newMetrics(cfg Config) (metrics, metric.Registration, error) {
 	for _, m := range histograms {
 		err := newFloat64Histogram(meter, m)
 		if err != nil {
-			return ms, nil, err
+			return &ms, nil, err
 		}
 	}
 
@@ -128,7 +128,7 @@ func newMetrics(cfg Config) (metrics, metric.Registration, error) {
 	for _, m := range counters {
 		err := newInt64Counter(meter, m)
 		if err != nil {
-			return ms, nil, err
+			return &ms, nil, err
 		}
 	}
 
@@ -138,7 +138,7 @@ func newMetrics(cfg Config) (metrics, metric.Registration, error) {
 		metric.WithDescription("Number of APM Events flushed to Elasticsearch. Dimensions are used to report the project ID, success or failures"),
 	)
 	if err != nil {
-		return ms, nil, fmt.Errorf("elasticsearch: failed to create metric for elasticsearch processed events: %w", err)
+		return &ms, nil, fmt.Errorf("elasticsearch: failed to create metric for elasticsearch processed events: %w", err)
 	}
 
 	reg, err := meter.RegisterCallback(func(_ context.Context, obs metric.Observer) error {
@@ -168,11 +168,11 @@ func newMetrics(cfg Config) (metrics, metric.Registration, error) {
 	)
 
 	if err != nil {
-		return ms, nil, fmt.Errorf("elasticsearch: failed to register metric callback: %w", err)
+		return &ms, nil, fmt.Errorf("elasticsearch: failed to register metric callback: %w", err)
 	}
 	fmt.Println("successfully registered callback")
 
-	return ms, reg, nil
+	return &ms, reg, nil
 }
 
 func newInt64Counter(meter metric.Meter, c counterMetric) error {


### PR DESCRIPTION
Instead of creating several metrics having status in names, create a single metric with different attributes/dimentions.

Before -> after
- `elasticsearch.events.processed` -> `elasticsearch.events.processed {status: "Success"}`
- `elasticsearch.failed.client.count ` ->  `elasticsearch.events.processed {status: "FailedClient"}`
- `elasticsearch.failed.server.count` -> `elasticsearch.events.processed {status: "FailedServer"}`
- `elasticsearch.failed.too_many_reqs` -> `elasticsearch.events.processed {status: "TooMany"}
`
