### PR TITLE
feat: dimensional metrics for `elasticsearch.events.processed` metric 

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -252,7 +252,7 @@ func (a *Appender) Add(ctx context.Context, index string, document io.Reader) er
 		return ErrClosed
 	case a.bulkItems <- item:
 	}
-	a.addProcessedCount(1, &a.docsAdded, a.metrics.docsAdded, Success)
+	a.addCount(1, &a.docsAdded, a.metrics.docsAdded)
 	a.addCount(1, &a.docsActive, a.metrics.docsActive)
 	return nil
 }
@@ -350,7 +350,7 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *bulkIndexer) error {
 		}
 	}
 	if docsFailed > 0 {
-		atomic.AddInt64(&a.docsFailed, int64(n))
+		atomic.AddInt64(&a.docsFailed, docsFailed)
 	}
 	if docsIndexed > 0 {
 		a.addProcessedCount(docsIndexed, &a.docsIndexed, a.metrics.docsIndexed, Success)

--- a/appender.go
+++ b/appender.go
@@ -141,7 +141,7 @@ func New(client *elasticsearch.Client, cfg Config) (*Appender, error) {
 		available:      available,
 		closed:         make(chan struct{}),
 		bulkItems:      make(chan bulkIndexerItem, cfg.DocumentBufferSize),
-		metrics:        *ms,
+		metrics:        ms,
 		telemetryAttrs: cfg.MetricAttributes,
 	}
 	indexer.addCount(int64(len(available)), &indexer.availableBulkRequests, ms.availableBulkRequests)

--- a/appender_test.go
+++ b/appender_test.go
@@ -411,7 +411,7 @@ func TestAppenderFlushMetric(t *testing.T) {
 			if !ignoreCount {
 				assert.Equal(t, count, int(dp.Count))
 			} else {
-				assert.Greater(t, int(dp.Count), count)
+				assert.GreaterOrEqual(t, int(dp.Count), count)
 			}
 			assert.Positive(t, dp.Sum)
 			assert.Equal(t, attrs, dp.Attributes)

--- a/appender_test.go
+++ b/appender_test.go
@@ -147,6 +147,7 @@ loop:
 		}
 	}
 
+	var processedAsserted int
 	assertProcessedCounter := func(metric metricdata.Metrics, count int64, attrs attribute.Set) {
 		asserted++
 		counter := metric.Data.(metricdata.Sum[int64])
@@ -156,12 +157,16 @@ loop:
 			assert.True(t, exist)
 			switch status.AsString() {
 			case "Success":
+				processedAsserted++
 				assert.Equal(t, stats.Indexed, dp.Value)
 			case "FailedClient":
+				processedAsserted++
 				assert.Equal(t, stats.FailedClient, dp.Value)
 			case "FailedServer":
+				processedAsserted++
 				assert.Equal(t, stats.FailedServer, dp.Value)
 			case "TooMany":
+				processedAsserted++
 				assert.Equal(t, stats.TooManyRequests, dp.Value)
 			default:
 				assert.FailNow(t, "Unexpected metric with status: "+status.AsString())
@@ -196,6 +201,7 @@ loop:
 	}
 	assert.Empty(t, unexpectedMetrics)
 	assert.Equal(t, 6, asserted)
+	assert.Equal(t, 4, processedAsserted)
 }
 
 func TestAppenderAvailableAppenders(t *testing.T) {
@@ -622,7 +628,6 @@ func TestAppenderCloseInterruptAdd(t *testing.T) {
 	defer cancel()
 	go func() {
 		added <- indexer.Add(addContext, "logs-foo-testing", readerFunc(func(p []byte) (int, error) {
-			fmt.Println("hello?")
 			close(readInvoked)
 			return copy(p, "{}"), nil
 		}))

--- a/metric.go
+++ b/metric.go
@@ -98,7 +98,7 @@ func newMetrics(cfg Config) (metrics, error) {
 		},
 		{
 			name:        "elasticsearch.events.processed",
-			description: "Number of APM Events flushed to Elasticsearch. Dimensions are used to report the project ID, success or failures",
+			description: "Number of APM Events flushed to Elasticsearch. Attributes are used to report separate counts for different outcomes - success, client failure, etc.",
 			p:           &ms.docsIndexed,
 		},
 		{

--- a/metric.go
+++ b/metric.go
@@ -31,7 +31,6 @@ type metrics struct {
 	bulkRequests          metric.Int64Counter
 	docsAdded             metric.Int64Counter
 	docsActive            metric.Int64Counter
-	docsFailed            metric.Int64Counter
 	docsIndexed           metric.Int64Counter
 	bytesTotal            metric.Int64Counter
 	availableBulkRequests metric.Int64Counter

--- a/metric.go
+++ b/metric.go
@@ -32,10 +32,7 @@ type metrics struct {
 	docsAdded             metric.Int64Counter
 	docsActive            metric.Int64Counter
 	docsFailed            metric.Int64Counter
-	docsFailedClient      metric.Int64Counter
-	docsFailedServer      metric.Int64Counter
 	docsIndexed           metric.Int64Counter
-	tooManyRequests       metric.Int64Counter
 	bytesTotal            metric.Int64Counter
 	availableBulkRequests metric.Int64Counter
 	activeCreated         metric.Int64Counter
@@ -56,7 +53,7 @@ type counterMetric struct {
 	p           *metric.Int64Counter
 }
 
-func newMetrics(cfg Config) (metrics, error) {
+func newMetrics(cfg Config) (*metrics, error) {
 	if cfg.MeterProvider == nil {
 		cfg.MeterProvider = otel.GetMeterProvider()
 	}
@@ -80,7 +77,7 @@ func newMetrics(cfg Config) (metrics, error) {
 	for _, m := range histograms {
 		err := newFloat64Histogram(meter, m)
 		if err != nil {
-			return ms, err
+			return &ms, err
 		}
 	}
 
@@ -92,7 +89,7 @@ func newMetrics(cfg Config) (metrics, error) {
 		},
 		{
 			name:        "elasticsearch.events.count",
-			description: "the total number of items added to the indexer.",
+			description: "Number of APM Events received for indexing",
 			p:           &ms.docsAdded,
 		},
 		{
@@ -101,29 +98,9 @@ func newMetrics(cfg Config) (metrics, error) {
 			p:           &ms.docsActive,
 		},
 		{
-			name:        "elasticsearch.failed.count",
-			description: "The amount of time a document was buffered for, in seconds.",
-			p:           &ms.docsFailed,
-		},
-		{
-			name:        "elasticsearch.failed.client.count",
-			description: "The number of docs failed to get indexed with client error(status_code >= 400 < 500, but not 429).",
-			p:           &ms.docsFailedClient,
-		},
-		{
-			name:        "elasticsearch.failed.server.count",
-			description: "The number of docs failed to get indexed with server error(status_code >= 500).",
-			p:           &ms.docsFailedServer,
-		},
-		{
 			name:        "elasticsearch.events.processed",
-			description: "The number of docs indexed successfully.",
+			description: "Number of APM Events flushed to Elasticsearch. Dimensions are used to report the project ID, success or failures",
 			p:           &ms.docsIndexed,
-		},
-		{
-			name:        "elasticsearch.failed.too_many_reqs",
-			description: "The number of 429 errors returned from the bulk indexer due to too many requests.",
-			p:           &ms.tooManyRequests,
 		},
 		{
 			name:        "elasticsearch.flushed.bytes",
@@ -150,11 +127,11 @@ func newMetrics(cfg Config) (metrics, error) {
 	for _, m := range counters {
 		err := newInt64Counter(meter, m)
 		if err != nil {
-			return ms, err
+			return &ms, err
 		}
 	}
 
-	return ms, nil
+	return &ms, nil
 }
 
 func newInt64Counter(meter metric.Meter, c counterMetric) error {

--- a/metric.go
+++ b/metric.go
@@ -52,7 +52,7 @@ type counterMetric struct {
 	p           *metric.Int64Counter
 }
 
-func newMetrics(cfg Config) (*metrics, error) {
+func newMetrics(cfg Config) (metrics, error) {
 	if cfg.MeterProvider == nil {
 		cfg.MeterProvider = otel.GetMeterProvider()
 	}
@@ -76,7 +76,7 @@ func newMetrics(cfg Config) (*metrics, error) {
 	for _, m := range histograms {
 		err := newFloat64Histogram(meter, m)
 		if err != nil {
-			return &ms, err
+			return ms, err
 		}
 	}
 
@@ -126,11 +126,11 @@ func newMetrics(cfg Config) (*metrics, error) {
 	for _, m := range counters {
 		err := newInt64Counter(meter, m)
 		if err != nil {
-			return &ms, err
+			return ms, err
 		}
 	}
 
-	return &ms, nil
+	return ms, nil
 }
 
 func newInt64Counter(meter metric.Meter, c counterMetric) error {


### PR DESCRIPTION
Instead of creating several metrics having status in names, create a single metric with different attributes/dimensions.

Before -> after
- `elasticsearch.events.processed` -> `elasticsearch.events.processed {status: "Success"}`
- `elasticsearch.failed.client.count ` ->  `elasticsearch.events.processed {status: "FailedClient"}`
- `elasticsearch.failed.server.count` -> `elasticsearch.events.processed {status: "FailedServer"}`
- `elasticsearch.failed.too_many_reqs` -> `elasticsearch.events.processed {status: "TooMany"}
`

The outcome of it is the same with the #53, but it uses synchronous instruments instead.