### PR TITLE
perf: use filter_path to ignore unused bulk response fields

### DIFF
--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -212,7 +212,7 @@ func (b *bulkIndexer) Flush(ctx context.Context) (BulkIndexerResponseStat, error
 	req := esapi.BulkRequest{
 		Body:       &b.buf,
 		Header:     make(http.Header),
-		FilterPath: []string{"items.**._index", "items.**.status", "items.**.error.type", "items.**.error.reason"},
+		FilterPath: []string{"items.*._index", "items.*.status", "items.*.error.type", "items.*.error.reason"},
 	}
 	if b.gzipw != nil {
 		req.Header.Set("Content-Encoding", "gzip")


### PR DESCRIPTION
Closes https://github.com/elastic/go-docappender/issues/57