### PR TITLE
feat: add FlushTimeout config and use context timeout for flush requests

### DIFF
--- a/config.go
+++ b/config.go
@@ -66,6 +66,11 @@ type Config struct {
 	// If FlushInterval is zero, the default of 30 seconds will be used.
 	FlushInterval time.Duration
 
+	// FlushTimeout holds the flush timeout as a duration.
+	//
+	// If FlushTimeout is zero, no timeout will be used.
+	FlushTimeout time.Duration
+
 	// DocumentBufferSize sets the number of documents that can be buffered before
 	// they are stored in the active indexer buffer.
 	//


### PR DESCRIPTION
The ES client is using the err group context when flushing which means the bulk index request could hang forever.
This PR adds a FlushTimeout option which is passed to the flush context, ensuring a deadline is always present.
For backward compatibility and to avoid changing behaviour the default value is no timeout.