### PR TITLE
bulk_indexer: Use "create" constant

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -222,9 +222,6 @@ func (a *Appender) Add(ctx context.Context, index string, document io.Reader) er
 	item := bulkIndexerItem{
 		Index: index,
 		Body:  document,
-
-		// Appender is append-only, hence the action is always "create".
-		Action: "create",
 	}
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
Removes the `bulkIndexerItem.Action` field since it's set to a known value. Having all `bulkIndexerItem` with a field with the same value is unnecessary. It saves a few bytes of memory.

Benchmarks remain largely the same so that I won't expect a significant performance benefit, just more readable code and the removal of the redundant field.
```
benchstat main.txt main-action.txt                                                                                                                                                                       <region:us-east-1>
goos: darwin
goarch: arm64
pkg: github.com/elastic/go-docappender
                                      │   main.txt    │           main-action.txt           │
                                      │    sec/op     │    sec/op     vs base               │
Appender/NoCompression-12                1.044µ ± 43%   1.036µ ± 44%       ~ (p=0.684 n=10)
Appender/NoCompressionScaling-12         1.331µ ±  3%   1.208µ ±  7%  -9.24% (p=0.001 n=10)
Appender/BestSpeed-12                    1.238µ ±  5%   1.237µ ± 42%       ~ (p=0.926 n=10)
Appender/BestSpeedScaling-12            1221.0n ± 39%   997.4n ± 34%       ~ (p=0.280 n=10)
Appender/DefaultCompression-12           1.559µ ±  4%   1.543µ ±  4%       ~ (p=0.643 n=10)
Appender/DefaultCompressionScaling-12    1.580µ ±  3%   1.589µ ±  5%       ~ (p=0.470 n=10)
Appender/BestCompression-12              1.578µ ±  6%   1.545µ ±  2%  -2.12% (p=0.043 n=10)
Appender/BestCompressionScaling-12       1.603µ ±  5%   1.574µ ±  4%  -1.78% (p=0.041 n=10)
AppenderError-12                        1112.0n ± 29%   969.5n ± 20%       ~ (p=0.075 n=10)
geomean                                  1.346µ         1.275µ        -5.28%

                                      │   main.txt    │            main-action.txt             │
                                      │      B/s      │      B/s        vs base                │
Appender/NoCompression-12               122.5Mi ± 75%    123.4Mi ± 78%        ~ (p=0.684 n=10)
Appender/NoCompressionScaling-12        96.05Mi ±  3%   105.81Mi ±  7%  +10.16% (p=0.001 n=10)
Appender/BestSpeed-12                   103.3Mi ±  5%    103.3Mi ± 73%        ~ (p=0.986 n=10)
Appender/BestSpeedScaling-12            104.7Mi ± 65%    138.3Mi ± 32%        ~ (p=0.280 n=10)
Appender/DefaultCompression-12          81.98Mi ±  4%    82.81Mi ±  4%        ~ (p=0.645 n=10)
Appender/DefaultCompressionScaling-12   80.90Mi ±  3%    80.42Mi ±  5%        ~ (p=0.481 n=10)
Appender/BestCompression-12             81.00Mi ±  6%    82.74Mi ±  3%   +2.15% (p=0.043 n=10)
Appender/BestCompressionScaling-12      79.75Mi ±  5%    81.18Mi ±  4%   +1.79% (p=0.037 n=10)
AppenderError-12                        114.9Mi ± 41%    131.8Mi ± 25%        ~ (p=0.075 n=10)
geomean                                 94.93Mi          101.1Mi         +6.45%

                                      │   main.txt   │           main-action.txt           │
                                      │     B/op     │     B/op      vs base               │
Appender/NoCompression-12                 268.5 ± 6%     284.0 ± 6%       ~ (p=0.484 n=10)
Appender/NoCompressionScaling-12          284.0 ± 6%     284.5 ± 6%       ~ (p=0.765 n=10)
Appender/BestSpeed-12                     281.0 ± 2%     281.0 ± 1%       ~ (p=0.846 n=10)
Appender/BestSpeedScaling-12              280.0 ± 3%     278.5 ± 2%       ~ (p=0.885 n=10)
Appender/DefaultCompression-12            284.0 ± 2%     279.0 ± 2%       ~ (p=0.051 n=10)
Appender/DefaultCompressionScaling-12     283.0 ± 2%     283.5 ± 6%       ~ (p=0.926 n=10)
Appender/BestCompression-12               288.5 ± 2%     282.5 ± 2%  -2.08% (p=0.006 n=10)
Appender/BestCompressionScaling-12        285.0 ± 2%     284.5 ± 2%       ~ (p=0.343 n=10)
AppenderError-12                        3.988Ki ± 0%   3.978Ki ± 1%       ~ (p=0.615 n=10)
geomean                                   379.1          379.6       +0.12%

                                      │  main.txt  │           main-action.txt           │
                                      │ allocs/op  │ allocs/op   vs base                 │
Appender/NoCompression-12               8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=10) ¹
Appender/NoCompressionScaling-12        8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=10) ¹
Appender/BestSpeed-12                   8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=10) ¹
Appender/BestSpeedScaling-12            8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=10) ¹
Appender/DefaultCompression-12          8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=10) ¹
Appender/DefaultCompressionScaling-12   8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=10) ¹
Appender/BestCompression-12             8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=10) ¹
Appender/BestCompressionScaling-12      8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=10) ¹
AppenderError-12                        55.00 ± 0%   55.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                 9.911        9.911       +0.00%
```