### PR TITLE
feat: return an error when using small flush bytes with compression enabled

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -127,11 +127,11 @@ func New(client *elasticsearch.Client, cfg Config) (*Appender, error) {
 		}
 	}
 
-	minFlushBytes := 32 * 1024 // 32kb
+	minFlushBytes := 16 * 1024 // 16kb
 	if cfg.CompressionLevel != 0 && cfg.FlushBytes < minFlushBytes {
 		return nil, fmt.Errorf(
-			"flush bytes config value (%d) is too small and will be ignored with compression enabled. Use at least 32kb",
-			cfg.FlushBytes,
+			"flush bytes config value (%d) is too small and will be ignored with compression enabled. Use at least %d",
+			cfg.FlushBytes, minFlushBytes,
 		)
 	}
 


### PR DESCRIPTION
Closes https://github.com/elastic/go-docappender/issues/95

When compression is enabled the gzip writer will buffer data internally
which will cause the unerlying buffer to grow from 0 to n once compression
happens and compressed data are flushed.
Because of this, small flush bytes values are ignored and will never be hit.
The PR returns an error when using a small flush bytes value with compression
enabled.

Users of this library are encouraged to have their own minimum value, log a warning and pass a bigger value if the value is too small.