### PR TITLE
github-action: enable bench diff and opentelemetry for all the GitHub workflows

### DIFF
--- a/.github/workflows/bench-diff.yml
+++ b/.github/workflows/bench-diff.yml
@@ -1,0 +1,56 @@
+name: bench-diff
+on:
+  push:
+  pull_request_target:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  run-benchdiff:
+    runs-on: ubuntu-latest
+    # Support for branches, non-forked-prs or forked-prs with a label
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'safe-to-test') ||
+      github.event_name != 'pull_request' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+    permissions:
+      checks: write
+    steps:
+    - name: Get sha commit
+      id: event
+      run: |
+        echo "DEBUG: event type(${{ github.event_name }})"
+        if [ "${{ github.event_name != 'pull_request_target' }}" = "true" ] ; then
+          echo "ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+        fi
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+        ref: ${{ steps.event.outputs.ref }}
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    # Version: https://github.com/WillAbides/benchdiff-action/releases/tag/v0.3.3
+    - uses: WillAbides/benchdiff-action@990b4c50b5420b485bf87e42c9f18234eba76fbc
+      id: benchdiff
+      with:
+        benchdiff_version: 0.9.1
+        status_sha: ${{ steps.event.outputs.ref }}
+        status_name: benchdiff-result
+        status_on_degraded: neutral
+        # See https://github.com/WillAbides/benchdiff
+        benchdiff_args: |
+          --base-ref=origin/main
+          --cpu=1,2
+          --count=5
+          --warmup-count=1
+          --warmup-time=10ms
+          --benchtime=100ms
+          --tolerance=20
+          --benchmem
+          --debug

--- a/.github/workflows/bench-diff.yml
+++ b/.github/workflows/bench-diff.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
-    # Version: https://github.com/WillAbides/benchdiff-action/releases/tag/v0.3.3
+    # Version: https://github.com/WillAbides/benchdiff-action/releases/tag/v0.3.5
     - uses: WillAbides/benchdiff-action@990b4c50b5420b485bf87e42c9f18234eba76fbc
       id: benchdiff
       with:

--- a/.github/workflows/label-elastic-pull-requests.yml
+++ b/.github/workflows/label-elastic-pull-requests.yml
@@ -1,0 +1,29 @@
+name: "label-elastic-pull-requests"
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  safe-to-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check team membership for user
+      uses: elastic/get-user-teams-membership@1.1.0
+      id: checkUserMember
+      with:
+        username: ${{ github.actor }}
+        team: 'apm'
+        GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+    - name: Add safe-to-test label
+      uses: actions/github-script@v7
+      if: steps.checkUserMember.outputs.isTeamMember == 'true'
+      with:
+        github-token: ${{ secrets.APM_TECH_USER_TOKEN }}
+        script: |
+          github.rest.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ["safe-to-test"]
+          })

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -1,11 +1,15 @@
 ---
+# Look up results at https://ela.st/oblt-ci-cd-stats
+# There will be one service per GitHub repository, including the org name, and one Transaction per Workflow.
 name: OpenTelemetry Export Trace
 
 on:
   workflow_run:
-    workflows:
-      - ci
+    workflows: [ "*" ]
     types: [completed]
+
+permissions:
+  contents: read
 
 jobs:
   otel-export-trace:


### PR DESCRIPTION
### What

Enable the bench-diff report for PRs and branches.

Minor change to support wildcards for all the run GitHub workflows so they can be exported to traces using the OpenTelemetry.

### Tasks

- [x] Enable secret `APM_TECH_USER_TOKEN`

### Implementation details

https://github.com/elastic/apm-data/pull/170 is a similar one but in a different GitHub repository.

Run the go test command with the bench flag using https://github.com/WillAbides/benchdiff-action and report the results with a link to the output using a GitHub check.

For such, it uses the current PR and the `main` branch revisions to run a go test command for each revision and compare with.

https://github.com/WillAbides/benchdiff-action?tab=readme-ov-file#benchdiff_args explains how to configure the benchdiff.

### Tests

See https://github.com/elastic/go-docappender/pull/113/checks?check_run_id=21203555733

### Issues

Closes #112