### PR TITLE
github-action: support pull_request_target and pull_request events

### DIFF
--- a/.github/workflows/bench-diff.yml
+++ b/.github/workflows/bench-diff.yml
@@ -13,8 +13,8 @@ jobs:
     # Support for branches, non-forked-prs or forked-prs with a label
     if: |
       contains(github.event.pull_request.labels.*.name, 'safe-to-test') ||
-      github.event_name != 'pull_request' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+      ! startsWith(github.event_name, 'pull_request') ||
+      (startsWith(github.event_name, 'pull_request') && github.event.pull_request.head.repo.fork == false)
     permissions:
       checks: write
     steps:
@@ -22,11 +22,11 @@ jobs:
       id: event
       run: |
         echo "DEBUG: event type(${{ github.event_name }})"
-        if [ "${{ github.event_name != 'pull_request_target' }}" = "true" ] ; then
-          echo "ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-        else
+        ref="${{ github.sha }}"
+        if [ "${{ startsWith(github.event_name, 'pull_request') }}" = "true" ] ; then
           echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
         fi
+        echo "ref=${ref}" >> "$GITHUB_OUTPUT"
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0


### PR DESCRIPTION
`github.event_name != 'pull_request'` will be always true since it listens for `pull_request_target` events.

Let's use the startswith condition for `pull_request`.