### PR TITLE
fix: wait for all the indexer to flush before returning

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -193,10 +193,14 @@ func (a *Appender) Close(ctx context.Context) error {
 		return err
 	}
 	close(a.available)
+	var errs []error
 	for bi := range a.available {
 		if err := a.flush(context.Background(), bi); err != nil {
-			return fmt.Errorf("failed to flush events on close: %w", err)
+			errs = append(errs, fmt.Errorf("indexer failed: %w", err))
 		}
+	}
+	if len(errs) != 0 {
+		return fmt.Errorf("failed to flush events on close: %w", errors.Join(errs...))
 	}
 	return nil
 }


### PR DESCRIPTION
do not return early if an indexer fails to flush, save the error and move on.

Wait for all the indexer in the `available` channel to finish flushing before returning.

Closes https://github.com/elastic/go-docappender/issues/117