### PR TITLE
feat: increase retry temp buffer size to 4096

### DIFF
--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -276,7 +276,7 @@ func (b *BulkIndexer) Flush(ctx context.Context) (BulkIndexerResponseStat, error
 
 	// Only run the retry logic if document retries are enabled
 	if b.maxDocumentRetry > 0 {
-		buf := make([]byte, 0, 1024)
+		buf := make([]byte, 0, 4096)
 
 		// Eliminate previous retry counts that aren't present in the bulk
 		// request response.


### PR DESCRIPTION
Closes https://github.com/elastic/go-docappender/issues/127

Increate retry temp buffer size to 4096. Prevents growing the buffer multiple times