### PR TITLE
Don't pass a reused bytes.Buffer to the ES client

### DIFF
--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -290,7 +290,7 @@ func (b *BulkIndexer) Flush(ctx context.Context) (BulkIndexerResponseStat, error
 		// This can cause undefined behavior (and panics) due to concurrent reads/writes to bytes.Buffer
 		// internal member variables (b.buf.off, b.buf.lastRead).
 		// See: https://github.com/golang/go/issues/51907
-		Body:       bytes.NewBuffer(b.buf.Bytes()),
+		Body:       bytes.NewReader(b.buf.Bytes()),
 		Header:     make(http.Header),
 		FilterPath: []string{"items.*._index", "items.*.status", "items.*.error.type", "items.*.error.reason"},
 		Pipeline:   b.config.Pipeline,

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -282,7 +282,15 @@ func (b *BulkIndexer) Flush(ctx context.Context) (BulkIndexerResponseStat, error
 	}
 
 	req := esapi.BulkRequest{
-		Body:       &b.buf,
+		// We should not pass the original b.buf bytes.Buffer down to the client/http layer because
+		// the indexer will reuse the buffer. The underlying http client/transport implementation may keep
+		// reading from the buffer after the request is done and the call to `req.Do` has returned.
+		// This may happen in HTTP error cases when the server isn't required to read the full
+		// request body before sending a response.
+		// This can cause undefined behavior (and panics) due to concurrent reads/writes to bytes.Buffer
+		// internal member variables (b.buf.off, b.buf.lastRead).
+		// See: https://github.com/golang/go/issues/51907
+		Body:       bytes.NewBuffer(b.buf.Bytes()),
 		Header:     make(http.Header),
 		FilterPath: []string{"items.*._index", "items.*.status", "items.*.error.type", "items.*.error.reason"},
 		Pipeline:   b.config.Pipeline,


### PR DESCRIPTION
See comments.

Directly passing a reusable bytes.Buffer is unsafe because of potential race condition on error scenarios introduced by the underlying RoundTripper implementation.

See:
https://pkg.go.dev/net/http#RoundTripper
> 	// RoundTrip must always close the body, including on errors,
	// but depending on the implementation may do so in a separate
	// goroutine even after RoundTrip returns. **This means that
	// callers wanting to reuse the body for subsequent requests
	// must arrange to wait for the Close call before doing so.**

We don't need a full copy of the buffer underlying slice since the sending goroutine is only reading from the buffer. We just need to make sure that `bytes.Buffer` other member variables aren't accessed and modified concurrently by different goroutines.

The call to `bytes.NewBuffer(b.buf.Bytes())` mimics what's done internally by the `net/http` library (and other implementations) on every retry: https://github.com/golang/go/blob/08e73e61521d7b83198407211aa232ed4f572f18/src/net/http/request.go#L929 - that is, taking the underlying byte slice and wrapping it in a brand new bytes.Buffer prior to any retry.

Note that `GetBody` is generally not invoked on the first try of a request, which means the original request body is directly read from. Prior to this PR, `b.buf` could be directly read from even after the call to `req.Do` returned.

Related: https://github.com/golang/go/issues/51907