### PR TITLE
feat: optionally enable logging the full error reason

### DIFF
--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"net/http"
 	"slices"
-	"strings"
 	"unsafe"
 
 	"github.com/klauspost/compress/gzip"
@@ -128,12 +127,7 @@ func init() {
 									case "type":
 										item.Error.Type = i.ReadString()
 									case "reason":
-										// Match Elasticsearch field mapper field value:
-										// failed to parse field [%s] of type [%s] in %s. Preview of field's value: '%s'
-										// https://github.com/elastic/elasticsearch/blob/588eabe185ad319c0268a13480465966cef058cd/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java#L234
-										item.Error.Reason, _, _ = strings.Cut(
-											i.ReadString(), ". Preview",
-										)
+										item.Error.Reason = i.ReadString()
 									default:
 										i.Skip()
 									}

--- a/config.go
+++ b/config.go
@@ -105,6 +105,10 @@ type Config struct {
 	// MetricAttributes holds any extra attributes to set in the recorded
 	// metrics.
 	MetricAttributes attribute.Set
+
+	// CaptureFullErrorReason enables the logger to collect the full error.reason
+	// returned by Elasticsearch when failed to index. default to false
+	CaptureFullErrorReason bool
 }
 
 // ScalingConfig holds the docappender autoscaling configuration.


### PR DESCRIPTION
Log the full error reason when configured.

This shouldn't be enabled by default as it is advised to redact the full context.