### PR TITLE
feat: capture caused_by and return it as part of `BulkIndexerResponseItem`

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -391,9 +391,10 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *BulkIndexer) error {
 		}
 	}
 	for key, count := range failedCount {
-		logger.Error(fmt.Sprintf("failed to index documents in '%s' (%s): %s",
+		logger.Error(fmt.Sprintf("failed to index documents in '%s' (%s): %s, caused_by (%s): %s",
 			key.Index, key.Error.Type, key.Error.Reason,
-		), zap.Int("documents", count))
+			key.Error.Cause.Type, key.Error.Cause.Reason),
+			zap.Int("documents", count))
 	}
 	if docsFailed > 0 {
 		atomic.AddInt64(&a.docsFailed, docsFailed)

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -102,9 +102,14 @@ type BulkIndexerResponseItem struct {
 	Position int
 
 	Error struct {
-		Type   string `json:"type"`
-		Reason string `json:"reason"`
+		Error
+		CausedBy Error `json:"error,omitempty"`
 	} `json:"error,omitempty"`
+}
+
+type Error struct {
+	Type   string `json:"type"`
+	Reason string `json:"reason"`
 }
 
 func init() {
@@ -134,6 +139,18 @@ func init() {
 										item.Error.Reason, _, _ = strings.Cut(
 											i.ReadString(), ". Preview",
 										)
+									case "caused_by":
+										i.ReadObjectCB(func(i *jsoniter.Iterator, s string) bool {
+											switch s {
+											case "type":
+												item.Error.CausedBy.Type = i.ReadString()
+											case "reason":
+												item.Error.CausedBy.Reason = i.ReadString()
+											default:
+												i.Skip()
+											}
+											return true
+										})
 									default:
 										i.Skip()
 									}

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -102,14 +102,13 @@ type BulkIndexerResponseItem struct {
 	Position int
 
 	Error struct {
-		Error
-		CausedBy Error `json:"error,omitempty"`
+		Type   string `json:"type"`
+		Reason string `json:"reason"`
+		Cause  struct {
+			Type   string `json:"type"`
+			Reason string `json:"reason"`
+		} `json:"caused_by"`
 	} `json:"error,omitempty"`
-}
-
-type Error struct {
-	Type   string `json:"type"`
-	Reason string `json:"reason"`
 }
 
 func init() {
@@ -143,9 +142,9 @@ func init() {
 										i.ReadObjectCB(func(i *jsoniter.Iterator, s string) bool {
 											switch s {
 											case "type":
-												item.Error.CausedBy.Type = i.ReadString()
+												item.Error.Cause.Type = i.ReadString()
 											case "reason":
-												item.Error.CausedBy.Reason = i.ReadString()
+												item.Error.Cause.Reason = i.ReadString()
 											default:
 												i.Skip()
 											}


### PR DESCRIPTION
closes #166 

Parse `caused_by` from the response, and add it to `BulkIndexerResponseItem` so that it can be logged.

#### TODO
- [ ] Decide whether to make it optional (verbose:on/off)
- [ ] Manual testing