### PR TITLE
metric: add success dimension to `elasticsearch.flushed.uncompressed.bytes`

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -337,12 +337,12 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *BulkIndexer) error {
 	// Record the BulkIndexer uncompressed bytes written to the buffer
 	// as the bytesUncompressedTotal metric after the request has been flushed.
 	if flushed := bulkIndexer.BytesUncompressedFlushed(); flushed > 0 {
-		a.addCount(resp.FlushedUncompressedSucceeded,
+		a.addCount(resp.FlushedUncompressedBytesOK,
 			&a.bytesUncompressedTotal,
 			a.metrics.bytesUncompressedTotal,
 			metric.WithAttributes(attribute.String("outcome", "success")),
 		)
-		a.addCount(int64(flushed)-resp.FlushedUncompressedSucceeded,
+		a.addCount(int64(flushed)-resp.FlushedUncompressedBytesOK,
 			&a.bytesUncompressedTotal,
 			a.metrics.bytesUncompressedTotal,
 			metric.WithAttributes(attribute.String("outcome", "failure")),

--- a/appender.go
+++ b/appender.go
@@ -337,7 +337,16 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *BulkIndexer) error {
 	// Record the BulkIndexer uncompressed bytes written to the buffer
 	// as the bytesUncompressedTotal metric after the request has been flushed.
 	if flushed := bulkIndexer.BytesUncompressedFlushed(); flushed > 0 {
-		a.addCount(int64(flushed), &a.bytesUncompressedTotal, a.metrics.bytesUncompressedTotal)
+		a.addCount(resp.FlushedUncompressedSucceeded,
+			&a.bytesUncompressedTotal,
+			a.metrics.bytesUncompressedTotal,
+			metric.WithAttributes(attribute.String("outcome", "success")),
+		)
+		a.addCount(int64(flushed)-resp.FlushedUncompressedSucceeded,
+			&a.bytesUncompressedTotal,
+			a.metrics.bytesUncompressedTotal,
+			metric.WithAttributes(attribute.String("outcome", "failure")),
+		)
 	}
 	if err != nil {
 		a.addUpDownCount(-int64(n), &a.docsActive, a.metrics.docsActive)

--- a/appender_test.go
+++ b/appender_test.go
@@ -313,6 +313,29 @@ loop:
 			}
 		}
 	}
+	var flushedAsserted int
+	var fb int64
+	assertUncompressedFlushed := func(metric metricdata.Metrics, attrs attribute.Set) {
+		asserted.Add(1)
+		counter := metric.Data.(metricdata.Sum[int64])
+		for _, dp := range counter.DataPoints {
+			metricdatatest.AssertHasAttributes(t, dp, attrs.ToSlice()...)
+			status, exist := dp.Attributes.Value(attribute.Key("outcome"))
+			assert.True(t, exist)
+			switch status.AsString() {
+			case "success":
+				flushedAsserted++
+				fb += dp.Value
+			case "failure":
+				flushedAsserted++
+				fb += dp.Value
+			default:
+				assert.FailNow(t, "Unexpected metric with outcome: "+status.AsString())
+			}
+		}
+		assert.Equal(t, stats.BytesUncompressedTotal, bytesTotal)
+		assert.Equal(t, stats.BytesUncompressedTotal, fb)
+	}
 	// check the set of names and then check the counter or histogram
 	unexpectedMetrics := []string{}
 	docappendertest.AssertOTelMetrics(t, rm.ScopeMetrics[0].Metrics, func(m metricdata.Metrics) {
@@ -332,7 +355,7 @@ loop:
 		case "elasticsearch.flushed.bytes":
 			assertCounter(m, stats.BytesTotal, indexerAttrs)
 		case "elasticsearch.flushed.uncompressed.bytes":
-			assertCounter(m, stats.BytesUncompressedTotal, indexerAttrs)
+			assertUncompressedFlushed(m, indexerAttrs)
 		case "elasticsearch.buffer.latency", "elasticsearch.flushed.latency":
 			// expect this metric name but no assertions done
 			// as it's histogram and it's checked elsewhere
@@ -344,6 +367,7 @@ loop:
 	assert.Empty(t, unexpectedMetrics)
 	assert.Equal(t, int64(8), asserted.Load())
 	assert.Equal(t, 3, processedAsserted)
+	assert.Equal(t, 2, flushedAsserted)
 
 	// Closing the indexer flushes enqueued documents.
 	err = indexer.Close(context.Background())

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -89,10 +89,10 @@ type BulkIndexer struct {
 }
 
 type BulkIndexerResponseStat struct {
-	Indexed                      int64
-	RetriedDocs                  int64
-	FailedDocs                   []BulkIndexerResponseItem
-	FlushedUncompressedSucceeded int64
+	Indexed                    int64
+	RetriedDocs                int64
+	FailedDocs                 []BulkIndexerResponseItem
+	FlushedUncompressedBytesOK int64
 }
 
 // BulkIndexerResponseItem represents the Elasticsearch response item.
@@ -392,11 +392,11 @@ func (b *BulkIndexer) Flush(ctx context.Context) (BulkIndexerResponseStat, error
 				continue
 			}
 			if len(b.writer.bytesWritten) > i {
-				resp.FlushedUncompressedSucceeded += int64(b.writer.bytesWritten[i])
+				resp.FlushedUncompressedBytesOK += int64(b.writer.bytesWritten[i])
 			}
 		}
 	} else {
-		resp.FlushedUncompressedSucceeded = int64(b.bytesUncompFlushed)
+		resp.FlushedUncompressedBytesOK = int64(b.bytesUncompFlushed)
 	}
 
 	b.writer.reset()

--- a/bulk_indexer_test.go
+++ b/bulk_indexer_test.go
@@ -127,4 +127,58 @@ func TestBulkIndexer(t *testing.T) {
 			require.Equal(t, 0, indexer.UncompressedLen())
 		})
 	}
+	t.Run("stat", func(t *testing.T) {
+		for _, tc := range []struct {
+			Name             string
+			CompressionLevel int
+		}{
+			// {Name: "no_compression", CompressionLevel: gzip.NoCompression},
+			{Name: "default_compression", CompressionLevel: gzip.DefaultCompression},
+		} {
+			client := docappendertest.NewMockElasticsearchClient(t, func(w http.ResponseWriter, r *http.Request) {
+				_, result := docappendertest.DecodeBulkRequest(r)
+				for i, itemsMap := range result.Items {
+					// mark odd item as failed
+					if i%2 == 0 {
+						continue
+					}
+					for k, item := range itemsMap {
+						result.HasErrors = true
+						item.Status = http.StatusTooManyRequests
+						item.Error.Type = "simulated_es_error"
+						item.Error.Reason = "for testing"
+						itemsMap[k] = item
+					}
+				}
+				json.NewEncoder(w).Encode(result)
+			})
+			indexer, err := docappender.NewBulkIndexer(docappender.BulkIndexerConfig{
+				Client:             client,
+				MaxDocumentRetries: 0, // disable retry
+				CompressionLevel:   tc.CompressionLevel,
+			})
+			require.NoError(t, err)
+
+			generateLoad := func(count int) {
+				for i := 0; i < count; i++ {
+					require.NoError(t, indexer.Add(docappender.BulkIndexerItem{
+						Index: "testidx",
+						Body: newJSONReader(map[string]any{
+							"foo": "boo",
+						}),
+					}))
+				}
+			}
+			itemCount := 100
+			generateLoad(itemCount)
+			stat, err := indexer.Flush(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, int64(itemCount/2), stat.Indexed)
+			require.Equal(t, itemCount/2, len(stat.FailedDocs))
+			// compressed: less than total
+			// uncompressed: half of the total
+			require.Equal(t, int64(indexer.BytesUncompressedFlushed()/2), stat.FlushedUncompressedSucceeded)
+			require.LessOrEqual(t, stat.FlushedSucceeded, int64(indexer.BytesFlushed()))
+		}
+	})
 }

--- a/bulk_indexer_test.go
+++ b/bulk_indexer_test.go
@@ -175,10 +175,7 @@ func TestBulkIndexer(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, int64(itemCount/2), stat.Indexed)
 			require.Equal(t, itemCount/2, len(stat.FailedDocs))
-			// compressed: less than total
-			// uncompressed: half of the total
 			require.Equal(t, int64(indexer.BytesUncompressedFlushed()/2), stat.FlushedUncompressedSucceeded)
-			require.LessOrEqual(t, stat.FlushedSucceeded, int64(indexer.BytesFlushed()))
 		}
 	})
 }


### PR DESCRIPTION

Should be ready to review when knowing the increased memory usage