### PR TITLE
Fix retried docs to not be in FailedDocs

### DIFF
--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -491,9 +491,7 @@ func (b *BulkIndexer) Flush(ctx context.Context) (BulkIndexerResponseStat, error
 			}
 		}
 
-		if len(tmp) > 0 {
-			resp.FailedDocs = tmp
-		}
+		resp.FailedDocs = tmp
 	}
 
 	return resp, nil

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -491,6 +491,7 @@ func (b *BulkIndexer) Flush(ctx context.Context) (BulkIndexerResponseStat, error
 			}
 		}
 
+		// FailedDocs contain responses of non-retriable errors OR retriable errors that reached the retry limit
 		resp.FailedDocs = tmp
 	}
 

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -491,7 +491,9 @@ func (b *BulkIndexer) Flush(ctx context.Context) (BulkIndexerResponseStat, error
 			}
 		}
 
-		// FailedDocs contain responses of non-retriable errors OR retriable errors that reached the retry limit
+		// FailedDocs contain responses of
+		// - non-retriable errors
+		// - retriable errors that reached the retry limit
 		resp.FailedDocs = tmp
 	}
 

--- a/bulk_indexer_test.go
+++ b/bulk_indexer_test.go
@@ -102,7 +102,7 @@ func TestBulkIndexer(t *testing.T) {
 				stat, err := indexer.Flush(context.Background())
 				require.NoError(t, err)
 				require.Equal(t, int64(0), stat.Indexed)
-				require.Equal(t, itemCount, len(stat.FailedDocs))
+				require.Len(t, stat.FailedDocs, 0)
 				require.Equal(t, int64(itemCount), stat.RetriedDocs)
 
 				// all the flushed bytes are now in the buffer again to be retried


### PR DESCRIPTION
A document should either be retried or failed in a request.
