### PR TITLE
bulk_indexer: track all response status codes

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -348,21 +348,30 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *BulkIndexer) error {
 		}
 
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			a.addCount(int64(n),
-				nil,
+			a.addCount(int64(n), nil,
 				a.metrics.docsIndexed,
 				metric.WithAttributes(attribute.String("status", "Timeout")),
 			)
 		}
 
-		var errTooMany errorTooManyRequests
-		// 429 may be returned as errors from the bulk indexer.
-		if errors.As(err, &errTooMany) {
-			a.addCount(int64(n),
-				&a.tooManyRequests,
-				a.metrics.docsIndexed,
-				metric.WithAttributes(attribute.String("status", "TooMany")),
-			)
+		// Bulk indexing may fail with different status codes.
+		var errFailed errorFlushFailed
+		if errors.As(err, &errFailed) {
+			var legacy *int64
+			var status string
+			switch {
+			case errFailed.tooMany:
+				legacy, status = &a.tooManyRequests, "TooMany"
+			case errFailed.clientError:
+				legacy, status = &a.docsFailedClient, "FailedClient"
+			case errFailed.serverError:
+				legacy, status = &a.docsFailedServer, "FailedServer"
+			}
+			if status != "" {
+				a.addCount(int64(n), legacy, a.metrics.docsIndexed,
+					metric.WithAttributes(attribute.String("status", status)),
+				)
+			}
 		}
 		return err
 	}
@@ -408,35 +417,28 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *BulkIndexer) error {
 	}
 	if resp.RetriedDocs > 0 {
 		// docs are scheduled to be retried but not yet failed due to retry limit
-		a.addCount(resp.RetriedDocs,
-			nil,
-			a.metrics.docsRetried,
-		)
+		a.addCount(resp.RetriedDocs, nil, a.metrics.docsRetried)
 	}
 	if docsIndexed > 0 {
-		a.addCount(docsIndexed,
-			&a.docsIndexed,
+		a.addCount(docsIndexed, &a.docsIndexed,
 			a.metrics.docsIndexed,
 			metric.WithAttributes(attribute.String("status", "Success")),
 		)
 	}
 	if tooManyRequests > 0 {
-		a.addCount(tooManyRequests,
-			&a.tooManyRequests,
+		a.addCount(tooManyRequests, &a.tooManyRequests,
 			a.metrics.docsIndexed,
 			metric.WithAttributes(attribute.String("status", "TooMany")),
 		)
 	}
 	if clientFailed > 0 {
-		a.addCount(clientFailed,
-			&a.docsFailedClient,
+		a.addCount(clientFailed, &a.docsFailedClient,
 			a.metrics.docsIndexed,
 			metric.WithAttributes(attribute.String("status", "FailedClient")),
 		)
 	}
 	if serverFailed > 0 {
-		a.addCount(serverFailed,
-			&a.docsFailedServer,
+		a.addCount(serverFailed, &a.docsFailedServer,
 			a.metrics.docsIndexed,
 			metric.WithAttributes(attribute.String("status", "FailedServer")),
 		)

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -351,10 +351,19 @@ func (b *BulkIndexer) Flush(ctx context.Context) (BulkIndexerResponseStat, error
 	b.bytesUncompFlushed = bytesUncompFlushed
 	var resp BulkIndexerResponseStat
 	if res.IsError() {
-		if res.StatusCode == http.StatusTooManyRequests {
-			return resp, errorTooManyRequests{res: res}
+		e := errorFlushFailed{resp: res.String(), statusCode: res.StatusCode}
+		if res.StatusCode >= 400 {
+			if res.StatusCode == http.StatusTooManyRequests {
+				e.tooMany = true
+				return resp, e
+			}
+			if res.StatusCode >= 500 {
+				e.serverError = true
+				return resp, e
+			}
+			e.clientError = true
 		}
-		return resp, fmt.Errorf("flush failed: %s", res.String())
+		return resp, e
 	}
 
 	if err := jsoniter.NewDecoder(res.Body).Decode(&resp); err != nil {
@@ -530,10 +539,14 @@ func indexnth(s []byte, nth int, sep rune) int {
 	})
 }
 
-type errorTooManyRequests struct {
-	res *esapi.Response
+type errorFlushFailed struct {
+	resp        string
+	statusCode  int
+	tooMany     bool
+	clientError bool
+	serverError bool
 }
 
-func (e errorTooManyRequests) Error() string {
-	return fmt.Sprintf("flush failed: %s", e.res.String())
+func (e errorFlushFailed) Error() string {
+	return fmt.Sprintf("flush failed (%d): %s", e.statusCode, e.resp)
 }


### PR DESCRIPTION
Updates the bulk_indexer to track all response status codes and report them appropriately as metrics. Also refactors tests to make them more succinct.

Closes #172 