### PR TITLE
test: fix flaky TestAppenderFlushMetric

### DIFF
--- a/appender_test.go
+++ b/appender_test.go
@@ -590,7 +590,7 @@ func TestAppenderFlushMetric(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 
-	docs := 10
+	docs := 12
 	for i := 0; i < docs; i++ {
 		addMinimalDoc(t, indexer, fmt.Sprintf("logs-foo-testing-%d", i))
 	}


### PR DESCRIPTION
Fixes the flaky `TestAppenderFlushMetric` test by increasing the number of events sent to they will always span two bulk requests in size.

Tested using:

```
$ go test -run=TestAppenderFlushMetric -count=100 -failfast ./...
?   	github.com/elastic/go-docappender/v2/docappendertest	[no test files]
ok  	github.com/elastic/go-docappender/v2	5.870s
$ go test -race -run=TestAppenderFlushMetric -count=100 -failfast ./...
?   	github.com/elastic/go-docappender/v2/docappendertest	[no test files]
ok  	github.com/elastic/go-docappender/v2	7.385s
```