### PR TITLE
Support `require_data_stream` new config option

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -153,6 +153,7 @@ func New(client esapi.Transport, cfg Config) (*Appender, error) {
 			RetryOnDocumentStatus: cfg.RetryOnDocumentStatus,
 			CompressionLevel:      cfg.CompressionLevel,
 			Pipeline:              cfg.Pipeline,
+			RequireDataStream:     cfg.RequireDataStream,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("error creating bulk indexer: %w", err)

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -72,10 +72,9 @@ type BulkIndexerConfig struct {
 	// If Pipeline is empty, no ingest pipeline will be specified in the Bulk request.
 	Pipeline string
 
-	// RequireDataStream forces the auto creation of the underlying index.
-	// If set to true, an index will be created only if a matching index
-	// template is found and it contains a data stream template. When true,
-	// `require_data_stream=true` is set in the bulk request.
+	// RequireDataStream, If set to true, an index will be created only if a
+	// matching index template is found and it contains a data stream template.
+	// When true, `require_data_stream=true` is set in the bulk request.
 	//
 	// RequireDataStream is disabled by default.
 	RequireDataStream bool

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -75,6 +75,9 @@ type BulkIndexerConfig struct {
 	// RequireDataStream, If set to true, an index will be created only if a
 	// matching index template is found and it contains a data stream template.
 	// When true, `require_data_stream=true` is set in the bulk request.
+	// When false or not set, `require_data_stream` is not set in the bulk request.
+	// Which could cause a classic index to be created if no data stream template
+	// matches the index in the request.
 	//
 	// RequireDataStream is disabled by default.
 	RequireDataStream bool

--- a/config.go
+++ b/config.go
@@ -90,10 +90,9 @@ type Config struct {
 	// If Pipeline is empty, no ingest pipeline will be specified in the Bulk request.
 	Pipeline string
 
-	// RequireDataStream forces the auto creation of the underlying index.
-	// If set to true, an index will be created only if a matching index
-	// template is found and it contains a data stream template. When true,
-	// `require_data_stream=true` is set in the bulk request.
+	// RequireDataStream, If set to true, an index will be created only if a
+	// matching index template is found and it contains a data stream template.
+	// When true, `require_data_stream=true` is set in the bulk request.
 	//
 	// RequireDataStream is disabled by default.
 	RequireDataStream bool

--- a/config.go
+++ b/config.go
@@ -90,6 +90,14 @@ type Config struct {
 	// If Pipeline is empty, no ingest pipeline will be specified in the Bulk request.
 	Pipeline string
 
+	// RequireDataStream forces the auto creation of the underlying index.
+	// If set to true, an index will be created only if a matching index
+	// template is found and it contains a data stream template. When true,
+	// `require_data_stream=true` is set in the bulk request.
+	//
+	// RequireDataStream is disabled by default.
+	RequireDataStream bool
+
 	// Scaling configuration for the docappender.
 	//
 	// If unspecified, scaling is enabled by default.

--- a/config.go
+++ b/config.go
@@ -93,6 +93,9 @@ type Config struct {
 	// RequireDataStream, If set to true, an index will be created only if a
 	// matching index template is found and it contains a data stream template.
 	// When true, `require_data_stream=true` is set in the bulk request.
+	// When false or not set, `require_data_stream` is not set in the bulk request.
+	// Which could cause a classic index to be created if no data stream template
+	// matches the index in the request.
 	//
 	// RequireDataStream is disabled by default.
 	RequireDataStream bool


### PR DESCRIPTION
Adds a new `RequireDataStream` option to the Appender, and BulkIndexer configurations. When set, it will send `?require_data_stream=true` in the `_bulk` request to Elasticsearch.

Closes #110