### PR TITLE
add otel tracing support

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -327,7 +327,6 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *BulkIndexer) error {
 		// below with the trace.
 		logger = logger.With(apmzap.TraceContext(ctx)...)
 	} else if a.otelTracingEnabled() {
-		// NOTE: this is missing transaction type information. How is this conveyed in otel?
 		ctx, span = a.tracer.Start(ctx, "docappender.flush", trace.WithAttributes(
 			attribute.Int("documents", n),
 		))

--- a/appender.go
+++ b/appender.go
@@ -718,6 +718,8 @@ func (a *Appender) tracingEnabled() bool {
 	return a.config.Tracer != nil && a.config.Tracer.Recording()
 }
 
+// otelTracingEnabled checks whether we should be doing tracing
+// using otel tracer.
 func (a *Appender) otelTracingEnabled() bool {
 	return a.tracer != nil
 }

--- a/appender.go
+++ b/appender.go
@@ -33,6 +33,7 @@ import (
 	"go.elastic.co/apm/module/apmzap/v2"
 	"go.elastic.co/apm/v2"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -474,6 +475,9 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *BulkIndexer) error {
 		zap.Int64("docs_failed", docsFailed),
 		zap.Int64("docs_rate_limited", tooManyRequests),
 	)
+	if a.otelTracingEnabled() && span.IsRecording() {
+		span.SetStatus(codes.Ok, "")
+	}
 	return nil
 }
 

--- a/appender.go
+++ b/appender.go
@@ -88,6 +88,7 @@ type Appender struct {
 	mu                    sync.Mutex
 	closed                chan struct{}
 
+        // tracer is an OTel tracer, and should not be confused with `a.config.Tracer` which is an Elastic APM Tracer.
 	tracer trace.Tracer
 }
 

--- a/appender.go
+++ b/appender.go
@@ -692,7 +692,8 @@ func (a *Appender) indexFailureRate() float64 {
 
 // tracingEnabled checks whether we should be doing tracing
 func (a *Appender) tracingEnabled() bool {
-	return a.config.Tracer != nil && a.config.Tracer.Recording()
+	return (a.config.Tracer != nil && a.config.Tracer.Recording()) ||
+		a.config.OtelTracer != nil
 }
 
 // activeLimit returns the value of GOMAXPROCS * cfg.ActiveRatio. Which limits

--- a/appender.go
+++ b/appender.go
@@ -188,8 +188,8 @@ func New(client esapi.Transport, cfg Config) (*Appender, error) {
 		return nil
 	})
 
-	if cfg.Tracer == nil && cfg.OtelTracerProvider != nil {
-		indexer.tracer = cfg.OtelTracerProvider.Tracer("github.com/elastic/go-docappender.appender")
+	if cfg.Tracer == nil && cfg.TracerProvider != nil {
+		indexer.tracer = cfg.TracerProvider.Tracer("github.com/elastic/go-docappender.appender")
 	}
 
 	return indexer, nil

--- a/appender.go
+++ b/appender.go
@@ -361,7 +361,7 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *BulkIndexer) error {
 		logger.Error("bulk indexing request failed", zap.Error(err))
 		if a.tracingEnabled() {
 			apm.CaptureError(ctx, err).Send()
-		} else if a.otelTracingEnabled() {
+		} else if a.otelTracingEnabled() && span.IsRecording() {
 			span.RecordError(err)
 		}
 
@@ -414,7 +414,7 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *BulkIndexer) error {
 		failedCount[info]++
 		if a.tracingEnabled() {
 			apm.CaptureError(ctx, errors.New(info.Error.Reason)).Send()
-		} else if a.otelTracingEnabled() {
+		} else if a.otelTracingEnabled() && span.IsRecording() {
 			// trace.SpanFromContext(ctx).RecordError(errors.New(info.Error.Reason))
 			span.RecordError(errors.New(info.Error.Reason))
 		}

--- a/appender.go
+++ b/appender.go
@@ -702,8 +702,15 @@ func (a *Appender) indexFailureRate() float64 {
 
 // tracingEnabled checks whether we should be doing tracing
 func (a *Appender) tracingEnabled() bool {
-	return (a.config.Tracer != nil && a.config.Tracer.Recording()) ||
-		a.config.OtelTracer != nil
+	// FIXME: remove
+	fmt.Println(a.config.Tracer != nil && a.config.Tracer.Recording())
+	return a.config.Tracer != nil && a.config.Tracer.Recording()
+}
+
+func (a *Appender) otelTracingEnabled() bool {
+	// FIXME: remove
+	fmt.Println(a.config.OtelTracer != nil)
+	return a.config.OtelTracer != nil
 }
 
 // activeLimit returns the value of GOMAXPROCS * cfg.ActiveRatio. Which limits

--- a/appender.go
+++ b/appender.go
@@ -88,7 +88,8 @@ type Appender struct {
 	mu                    sync.Mutex
 	closed                chan struct{}
 
-        // tracer is an OTel tracer, and should not be confused with `a.config.Tracer` which is an Elastic APM Tracer.
+	// tracer is an OTel tracer, and should not be confused with `a.config.Tracer`
+	// which is an Elastic APM Tracer.
 	tracer trace.Tracer
 }
 

--- a/appender.go
+++ b/appender.go
@@ -415,7 +415,6 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *BulkIndexer) error {
 		if a.tracingEnabled() {
 			apm.CaptureError(ctx, errors.New(info.Error.Reason)).Send()
 		} else if a.otelTracingEnabled() && span.IsRecording() {
-			// trace.SpanFromContext(ctx).RecordError(errors.New(info.Error.Reason))
 			span.RecordError(errors.New(info.Error.Reason))
 		}
 	}

--- a/appender_test.go
+++ b/appender_test.go
@@ -1682,10 +1682,6 @@ func TestAppenderOtelTracing(t *testing.T) {
 	// Closing the indexer flushes enqueued documents.
 	require.NoError(t, indexer.Close(context.Background()))
 
-	require.NoError(t, tp.Shutdown(context.Background()))
-	err = exp.Shutdown(context.Background())
-	require.NoError(t, err)
-
 	spans := exp.GetSpans()
 	fmt.Println(len(spans))
 	assert.NotEmpty(t, spans)

--- a/appender_test.go
+++ b/appender_test.go
@@ -1761,8 +1761,8 @@ func testTracedAppend(t *testing.T, responseCode int, status sdktrace.Status) {
 		FlushInterval: time.Minute,
 		Logger:        zap.New(core),
 		// NOTE: Tracer must be nil to use otel tracing
-		Tracer:             nil,
-		OtelTracerProvider: tp,
+		Tracer:         nil,
+		TracerProvider: tp,
 	})
 	require.NoError(t, err)
 	defer indexer.Close(context.Background())

--- a/appender_test.go
+++ b/appender_test.go
@@ -39,6 +39,7 @@ import (
 	"go.elastic.co/apm/v2/apmtest"
 	"go.elastic.co/apm/v2/model"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
@@ -1687,6 +1688,7 @@ func TestAppenderOtelTracing(t *testing.T) {
 
 	gotSpan := spans[0]
 	assert.Equal(t, "docappender.flush", gotSpan.Name)
+	assert.Equal(t, sdktrace.Status{Code: codes.Ok}, gotSpan.Status)
 
 	for _, a := range gotSpan.Attributes {
 		if a.Key == "documents" {

--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ import (
 	"go.elastic.co/apm/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -42,6 +43,8 @@ type Config struct {
 	//
 	// If Tracer is nil, requests will not be traced.
 	Tracer *apm.Tracer
+
+	OtelTracer trace.Tracer
 
 	// CompressionLevel holds the gzip compression level, from 0 (gzip.NoCompression)
 	// to 9 (gzip.BestCompression). Higher values provide greater compression, at a

--- a/config.go
+++ b/config.go
@@ -46,12 +46,12 @@ type Config struct {
 	// be traced by a different tracer.
 	Tracer *apm.Tracer
 
-	// OtelTracerProvider holds an optional otel TracerProvider for tracing
+	// TracerProvider holds an optional otel TracerProvider for tracing
 	// flush requests.
 	//
-	// If OtelTracerProvider is nil, requests will not be traced.
+	// If TracerProvider is nil, requests will not be traced.
 	// To use this provider Tracer must be nil.
-	OtelTracerProvider trace.TracerProvider
+	TracerProvider trace.TracerProvider
 
 	// CompressionLevel holds the gzip compression level, from 0 (gzip.NoCompression)
 	// to 9 (gzip.BestCompression). Higher values provide greater compression, at a

--- a/config.go
+++ b/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	// If Tracer is nil, requests will not be traced.
 	Tracer *apm.Tracer
 
-	OtelTracer trace.Tracer
+	OtelTracerProvider trace.TracerProvider
 
 	// CompressionLevel holds the gzip compression level, from 0 (gzip.NoCompression)
 	// to 9 (gzip.BestCompression). Higher values provide greater compression, at a

--- a/config.go
+++ b/config.go
@@ -44,6 +44,9 @@ type Config struct {
 	// If Tracer is nil, requests will not be traced. Note however that
 	// OtelTracerProvider may not be nil, in which case the request will
 	// be traced by a different tracer.
+	//
+	// Deprecated: Tracer is replaced by TracerProvider in a shift towards
+	// OpenTelemetry. Please use TracerProvider.
 	Tracer *apm.Tracer
 
 	// TracerProvider holds an optional otel TracerProvider for tracing

--- a/config.go
+++ b/config.go
@@ -41,9 +41,16 @@ type Config struct {
 	// Tracer holds an optional apm.Tracer to use for tracing bulk requests
 	// to Elasticsearch. Each bulk request is traced as a transaction.
 	//
-	// If Tracer is nil, requests will not be traced.
+	// If Tracer is nil, requests will not be traced. Note however that
+	// OtelTracerProvider may not be nil, in which case the request will
+	// be traced by a different tracer.
 	Tracer *apm.Tracer
 
+	// OtelTracerProvider holds an optional otel TracerProvider for tracing
+	// flush requests.
+	//
+	// If OtelTracerProvider is nil, requests will not be traced.
+	// To use this provider Tracer must be nil.
 	OtelTracerProvider trace.TracerProvider
 
 	// CompressionLevel holds the gzip compression level, from 0 (gzip.NoCompression)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,9 @@ require (
 	go.elastic.co/fastjson v1.3.0
 	go.opentelemetry.io/otel v1.27.0
 	go.opentelemetry.io/otel/metric v1.27.0
+	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/sdk/metric v1.27.0
+	go.opentelemetry.io/otel/trace v1.27.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.7.0
 )
@@ -34,8 +36,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	go.elastic.co/apm/module/apmhttp/v2 v2.6.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.27.0 // indirect
-	go.opentelemetry.io/otel/trace v1.27.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
Add otel tracing support as a secondary tracing choice.

By default the current behaviour is retained: tracing with Elastic APM is preferred over otel tracing.
If Elastic APM tracing is not configured but otel tracing is, leverage otel tracing.

If no tracing is configured keep the current behaviour of skipping tracing.

Closes https://github.com/elastic/go-docappender/issues/45
