### PR TITLE
github-actions: use ephemeral tokens

### DIFF
--- a/.github/workflows/label-elastic-pull-requests.yml
+++ b/.github/workflows/label-elastic-pull-requests.yml
@@ -11,18 +11,29 @@ jobs:
   safe-to-test:
     runs-on: ubuntu-latest
     steps:
+    - name: Get token
+      id: get_token
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      with:
+        app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+        private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+        permissions: >-
+          {
+            "members": "read",
+            "pull_requests": "write"
+          }
     - name: Check team membership for user
       uses: elastic/get-user-teams-membership@1.1.0
       id: checkUserMember
       with:
         username: ${{ github.actor }}
         team: 'apm'
-        GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
     - name: Add safe-to-test label
       uses: actions/github-script@v7
       if: steps.checkUserMember.outputs.isTeamMember == 'true'
       with:
-        github-token: ${{ secrets.APM_TECH_USER_TOKEN }}
+        github-token: ${{ steps.get_token.outputs.token }}
         script: |
           github.rest.issues.addLabels({
             issue_number: context.issue.number,


### PR DESCRIPTION
No more finer-grained tokens but ephemeral tokens using a GH app