### PR TITLE
`elasticsearch.events.retried`: Add retry dimension

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -449,7 +449,9 @@ func (a *Appender) flush(ctx context.Context, bulkIndexer *BulkIndexer) error {
 	}
 	if resp.RetriedDocs > 0 {
 		// docs are scheduled to be retried but not yet failed due to retry limit
-		a.addCount(resp.RetriedDocs, nil, a.metrics.docsRetried)
+		a.addCount(resp.RetriedDocs, nil, a.metrics.docsRetried,
+			metric.WithAttributes(attribute.Int("greatest_retry", resp.GreatestRetry)),
+		)
 	}
 	if docsIndexed > 0 {
 		a.addCount(docsIndexed, &a.docsIndexed,

--- a/appender_test.go
+++ b/appender_test.go
@@ -329,7 +329,11 @@ loop:
 		case "elasticsearch.events.processed":
 			assertProcessedCounter(m, indexerAttrs)
 		case "elasticsearch.events.retried":
-			assertCounter(m, 1, indexerAttrs)
+			assertCounter(m, 1, attribute.NewSet(
+				attribute.String("a", "b"),
+				attribute.String("c", "d"),
+				attribute.Int("greatest_retry", 1),
+			))
 		case "elasticsearch.bulk_requests.available":
 			assertCounter(m, stats.AvailableBulkRequests, indexerAttrs)
 		case "elasticsearch.flushed.bytes":
@@ -1046,7 +1050,9 @@ func TestAppenderRetryDocument(t *testing.T) {
 			docappendertest.AssertOTelMetrics(t, rm.ScopeMetrics[0].Metrics, func(m metricdata.Metrics) {
 				switch m.Name {
 				case "elasticsearch.events.retried":
-					assertCounter(m, 5, *attribute.EmptySet())
+					assertCounter(m, 5, attribute.NewSet(
+						attribute.Int("greatest_retry", 1),
+					))
 				}
 			})
 			assert.Equal(t, int64(1), asserted.Load())
@@ -1064,7 +1070,9 @@ func TestAppenderRetryDocument(t *testing.T) {
 			docappendertest.AssertOTelMetrics(t, rm.ScopeMetrics[0].Metrics, func(m metricdata.Metrics) {
 				switch m.Name {
 				case "elasticsearch.events.retried":
-					assertCounter(m, 5, *attribute.EmptySet())
+					assertCounter(m, 5, attribute.NewSet(
+						attribute.Int("greatest_retry", 2),
+					))
 				}
 			})
 			assert.Equal(t, int64(2), asserted.Load())


### PR DESCRIPTION
This commit adds a new dimension to the `elasticsearch.events.retried` metric called `greatest_retry`. It represents the greatest observed retry count for a bulk request. This is useful to understand how many times documents in a bulk request have been retried.