### PR TITLE
Allow passing a custom item action

### DIFF
--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -58,7 +58,6 @@ const (
 	ActionUpdate = "update"
 )
 
-
 // BulkIndexerConfig holds configuration for BulkIndexer.
 type BulkIndexerConfig struct {
 	// Client holds the Elasticsearch client.

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -304,7 +304,10 @@ func (b *BulkIndexer) Add(item BulkIndexerItem) error {
 }
 
 func (b *BulkIndexer) writeMeta(index, documentID, pipeline, action string, dynamicTemplates map[string]string) {
-	b.jsonw.RawString(`{"` + action + `":{`)
+	b.jsonw.RawString(`{"`)
+	b.jsonw.RawString(action)
+	b.jsonw.RawString(`":{`)
+
 	first := true
 	if documentID != "" {
 		b.jsonw.RawString(`"_id":`)

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -49,6 +49,17 @@ import (
 // of concurrent bulk requests. This way we can ensure bulk requests have the
 // maximum possible size, based on configuration and throughput.
 
+const (
+	// Actions are all the actions that can be used when indexing data.
+	// `create` will be used by default.
+	ActionCreate = "create"
+	ActionDelete = "delete"
+	ActionIndex  = "index"
+	ActionUpdate = "update"
+)
+
+var allActions = []string{ActionCreate, ActionDelete, ActionIndex, ActionUpdate}
+
 // BulkIndexerConfig holds configuration for BulkIndexer.
 type BulkIndexerConfig struct {
 	// Client holds the Elasticsearch client.
@@ -289,7 +300,11 @@ type BulkIndexerItem struct {
 func (b *BulkIndexer) Add(item BulkIndexerItem) error {
 	action := item.Action
 	if action == "" {
-		action = "create"
+		action = ActionCreate
+	}
+
+	if !slices.Contains(allActions, action) {
+		return fmt.Errorf("%s is not a valid action", action)
 	}
 
 	b.writeMeta(item.Index, item.DocumentID, item.Pipeline, action, item.DynamicTemplates)

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -58,7 +58,6 @@ const (
 	ActionUpdate = "update"
 )
 
-var allActions = []string{ActionCreate, ActionDelete, ActionIndex, ActionUpdate}
 
 // BulkIndexerConfig holds configuration for BulkIndexer.
 type BulkIndexerConfig struct {

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -302,7 +302,9 @@ func (b *BulkIndexer) Add(item BulkIndexerItem) error {
 		action = ActionCreate
 	}
 
-	if !slices.Contains(allActions, action) {
+	switch action {
+	case ActionCreate, ActionDelete, ActionIndex, ActionUpdate:
+	default:
 		return fmt.Errorf("%s is not a valid action", action)
 	}
 

--- a/bulk_indexer_test.go
+++ b/bulk_indexer_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/elastic/go-docappender/v2"
 	"github.com/elastic/go-docappender/v2/docappendertest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -250,6 +251,16 @@ func TestAction(t *testing.T) {
 		}),
 	})
 	require.NoError(t, err)
+
+	err = indexer.Add(docappender.BulkIndexerItem{
+		Index:    "testidx",
+		Action:   "foobar",
+		Pipeline: "test-pipeline2",
+		Body: newJSONReader(map[string]any{
+			"@timestamp": time.Now().Format(docappendertest.TimestampFormat),
+		}),
+	})
+	assert.Error(t, err)
 
 	stat, err := indexer.Flush(context.Background())
 	require.NoError(t, err)


### PR DESCRIPTION
When manipulating profiles data, we need to be able to use the `Update` action rather than `Create` all the time.
So this change allows passing custom actions rather than hardcoding create.

If no actions is provided, the default value will be `create`.