### PR TITLE
Add function hooks to config

### DIFF
--- a/appender_test.go
+++ b/appender_test.go
@@ -106,17 +106,10 @@ func TestAppender(t *testing.T) {
 		attribute.String("a", "b"), attribute.String("c", "d"),
 	)
 
-	consumed := make(chan struct{})
 	indexer, err := docappender.New(client, docappender.Config{
 		FlushInterval:    time.Minute,
 		MeterProvider:    sdkmetric.NewMeterProvider(sdkmetric.WithReader(rdr)),
 		MetricAttributes: indexerAttrs,
-		OnConsume: func() {
-			select {
-			case consumed <- struct{}{}:
-			default:
-			}
-		},
 	})
 
 	require.NoError(t, err)
@@ -273,7 +266,6 @@ func TestAppenderRetry(t *testing.T) {
 		attribute.String("a", "b"), attribute.String("c", "d"),
 	)
 
-	flushed := make(chan struct{})
 	indexer, err := docappender.New(client, docappender.Config{
 		FlushInterval:      time.Minute,
 		FlushBytes:         750, // this is enough to flush after 9 documents
@@ -281,12 +273,6 @@ func TestAppenderRetry(t *testing.T) {
 		MaxDocumentRetries: 1,   // to test the document retry logic
 		MeterProvider:      sdkmetric.NewMeterProvider(sdkmetric.WithReader(rdr)),
 		MetricAttributes:   indexerAttrs,
-		OnFlush: func() {
-			select {
-			case flushed <- struct{}{}:
-			default:
-			}
-		},
 	})
 
 	require.NoError(t, err)

--- a/config.go
+++ b/config.go
@@ -158,12 +158,6 @@ type Config struct {
 	// MetricAttributes holds any extra attributes to set in the recorded
 	// metrics.
 	MetricAttributes attribute.Set
-
-	// OnConsume is a hook that will execute after a bulk item has been handled.
-	OnConsume func()
-
-	// OnFlush is a hook that will execute after a flush happens.
-	OnFlush func()
 }
 
 // DefaultConfig returns a copy of cfg with any zero values set to their

--- a/config.go
+++ b/config.go
@@ -159,8 +159,10 @@ type Config struct {
 	// metrics.
 	MetricAttributes attribute.Set
 
+	// OnConsume is a hook that will execute after a bulk item has been handled.
 	OnConsume func()
 
+	// OnFlush is a hook that will execute after a flush happens.
 	OnFlush func()
 }
 

--- a/config.go
+++ b/config.go
@@ -158,6 +158,8 @@ type Config struct {
 	// MetricAttributes holds any extra attributes to set in the recorded
 	// metrics.
 	MetricAttributes attribute.Set
+
+	OnConsume func()
 }
 
 // DefaultConfig returns a copy of cfg with any zero values set to their

--- a/config.go
+++ b/config.go
@@ -160,6 +160,8 @@ type Config struct {
 	MetricAttributes attribute.Set
 
 	OnConsume func()
+
+	OnFlush func()
 }
 
 // DefaultConfig returns a copy of cfg with any zero values set to their


### PR DESCRIPTION
Closes https://github.com/elastic/go-docappender/issues/252

Use function hooks to make unit tests more antifragile by leveraging Go concurrency primitives instead of waits, making the tests more expressive and deterministic.

- Replace [wait loop](https://github.com/elastic/go-docappender/blob/fb133108473302daf0a3f2c5f39b30e762d1de2e/appender_test.go#L119) in `TestAppender` with `OnConsume` hook.
- Replace [wait loop](https://github.com/elastic/go-docappender/blob/fb133108473302daf0a3f2c5f39b30e762d1de2e/appender_test.go#L293) in `TestAppenderRetry` with `OnFlush` hook.

