### PR TITLE
update test formating

### DIFF
--- a/appender_test.go
+++ b/appender_test.go
@@ -57,7 +57,13 @@ func TestAppenderWithFailureStore(t *testing.T) {
 	var bytesUncompressed int64
 	client := docappendertest.NewMockElasticsearchClient(t, func(w http.ResponseWriter, r *http.Request) {
 		require.Len(t, r.URL.Query(), 1)
-		require.Equal(t, strings.Join([]string{"items.*._index", "items.*.status", "items.*.failure_store", "items.*.error.type", "items.*.error.reason"}, ","), r.URL.Query().Get("filter_path"))
+		require.Equal(t, strings.Join([]string{
+			"items.*._index",
+			"items.*.status",
+			"items.*.failure_store",
+			"items.*.error.type",
+			"items.*.error.reason",
+		}, ","), r.URL.Query().Get("filter_path"))
 		bytesTotal += r.ContentLength
 		_, result, stat := docappendertest.DecodeBulkRequestWithStats(r)
 		bytesUncompressed += stat.UncompressedBytes

--- a/appender_test.go
+++ b/appender_test.go
@@ -52,7 +52,7 @@ import (
 	"github.com/elastic/go-docappender/v2/docappendertest"
 )
 
-func TestAppender(t *testing.T) {
+func TestAppenderWithFailureStore(t *testing.T) {
 	var bytesTotal int64
 	var bytesUncompressed int64
 	client := docappendertest.NewMockElasticsearchClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -238,7 +238,7 @@ func TestAppender(t *testing.T) {
 	assert.Equal(t, 7, processedAsserted)
 }
 
-func TestAppenderRetry(t *testing.T) {
+func TestAppenderRetryTooMany(t *testing.T) {
 	var bytesTotal int64
 	var bytesUncompressed int64
 	var first atomic.Bool


### PR DESCRIPTION
Closes https://github.com/elastic/go-docappender/issues/254

More description test naming. Also allows us to run individual tests:

```shell
go test -v -race ./... -run TestAppenderWithFailureStore
go test -v -race ./... -run TestAppenderRetryTooMany
```

Before this PR when running `go test -v -race ./... -run TestAppender`, most unit tests will run with the substring `TestAppender`