### PR TITLE
Add telemetry headers for bulk requests

### DIFF
--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -55,6 +55,9 @@ const (
 	ActionDelete = "delete"
 	ActionIndex  = "index"
 	ActionUpdate = "update"
+
+	HeaderEventCount         = "Event-Count"
+	HeaderUncompressedLength = "Content-Uncompressed-Length"
 )
 
 // BulkIndexer issues bulk requests to Elasticsearch. It is NOT safe for concurrent use
@@ -395,6 +398,8 @@ func (b *BulkIndexer) newBulkIndexRequest(ctx context.Context) (*http.Request, e
 	}
 
 	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add(HeaderEventCount, strconv.Itoa(b.itemsAdded))
+	req.Header.Add(HeaderUncompressedLength, strconv.Itoa(b.UncompressedLen()))
 	v := req.URL.Query()
 	if b.config.Pipeline != "" {
 		v.Set("pipeline", b.config.Pipeline)

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -56,8 +56,8 @@ const (
 	ActionIndex  = "index"
 	ActionUpdate = "update"
 
-	HeaderEventCount         = "Event-Count"
-	HeaderUncompressedLength = "Content-Uncompressed-Length"
+	HeaderEventCount         = "X-Elastic-Event-Count"
+	HeaderUncompressedLength = "X-Elastic-Content-Uncompressed-Length"
 )
 
 // BulkIndexer issues bulk requests to Elasticsearch. It is NOT safe for concurrent use

--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -57,7 +57,7 @@ const (
 	ActionUpdate = "update"
 
 	HeaderEventCount         = "X-Elastic-Event-Count"
-	HeaderUncompressedLength = "X-Elastic-Content-Uncompressed-Length"
+	HeaderUncompressedLength = "X-Elastic-Uncompressed-Request-Length"
 )
 
 // BulkIndexer issues bulk requests to Elasticsearch. It is NOT safe for concurrent use

--- a/docappendertest/docappendertest.go
+++ b/docappendertest/docappendertest.go
@@ -190,7 +190,10 @@ func decodeBulkRequest(r *http.Request) (
 		itemMeta.Action = actionType
 		meta = append(meta, itemMeta)
 	}
-	return docs, meta, result, RequestStats{int64(cr.bytesRead)}
+	return docs, meta, result, RequestStats{
+		UncompressedBytes: int64(cr.bytesRead),
+		EventCount:        int64(len(result.Items)),
+	}
 }
 
 // NewMockElasticsearchClient returns an elasticsearch.Client which sends /_bulk requests to bulkHandler.
@@ -267,4 +270,5 @@ func (c *countReader) Read(p []byte) (int, error) {
 
 type RequestStats struct {
 	UncompressedBytes int64
+	EventCount        int64
 }


### PR DESCRIPTION
This allow to collect telemetry for the size and count of documents sent to Elasticsearch.