### PR TITLE
Introduce merge and split experimental APIs for bulk indexers

### DIFF
--- a/bulk_indexer.go
+++ b/bulk_indexer.go
@@ -18,9 +18,11 @@
 package docappender
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -256,6 +258,21 @@ func (b *BulkIndexer) resetBuf() {
 	}
 }
 
+// Size returns the size of the buffer used by bulk indexer as per
+// the specified sizer type.
+// EXPERIMENTAL: This is an experimental API
+func (b *BulkIndexer) Size(sizerType SizerType) int {
+	switch sizerType {
+	case ItemsCountSizer:
+		return b.Items()
+	case UncompressedBytesSizer:
+		return b.UncompressedLen()
+	case CompressedBytesSizer:
+		return b.Len()
+	}
+	return b.Items()
+}
+
 // Items returns the number of buffered items.
 func (b *BulkIndexer) Items() int {
 	return b.itemsAdded
@@ -381,6 +398,126 @@ func (b *BulkIndexer) writeMeta(
 	b.jsonw.RawString("}}\n")
 	b.writer.Write(b.jsonw.Bytes())
 	b.jsonw.Reset()
+}
+
+// Merge merges another bulk indexer to the current one.
+// The merged bulk indexer should not be used after the method returns.
+//
+// EXPERIMENTAL: This is an experimental API and can be removed or
+// modified with breaking changes.
+func (b *BulkIndexer) Merge(other *BulkIndexer) error {
+	if b.config.CompressionLevel != other.config.CompressionLevel {
+		return errors.New("failed to merge bulk indexers, only same compression level merge is supported")
+	}
+	switch b.config.CompressionLevel {
+	case gzip.NoCompression:
+		if _, err := other.buf.WriteTo(b.writer); err != nil {
+			return fmt.Errorf("failed to merge uncompressed bulk indexers: %w", err)
+		}
+	default:
+		// All compression levels
+		if other.gzipw != nil {
+			if err := other.gzipw.Close(); err != nil {
+				return fmt.Errorf("failed to merge compressed bulk indexers:%w", err)
+			}
+		}
+		othergzip, err := gzip.NewReader(bytes.NewReader(other.buf.Bytes()))
+		if err != nil {
+			return fmt.Errorf("failed to merge compressed bulk indexers: %w", err)
+		}
+		defer othergzip.Close()
+		if _, err := othergzip.WriteTo(b.writer); err != nil {
+			return fmt.Errorf("failed to merge compressed bulk indexers: %w", err)
+		}
+	}
+	b.itemsAdded += other.itemsAdded
+	return nil
+}
+
+// Split splits the data in the current bulk indexer into multiple
+// bulk indexers based on the max size and the sizer type specified.
+// Do not use the original bulk indexer after the method returns.
+//
+// EXPERIMENTAL: This is an experimental API and can be removed or
+// modified with breaking changes.
+func (b *BulkIndexer) Split(maxSize int, sizerType SizerType) ([]*BulkIndexer, error) {
+	size := b.Size(sizerType)
+	if size == 0 || size <= maxSize {
+		return []*BulkIndexer{b}, nil
+	}
+
+	var err error
+	// Split of `b` is needed. If `gzip` writer is used then close it before splitting.
+	if b.gzipw != nil {
+		if err = b.gzipw.Close(); err != nil {
+			return nil, fmt.Errorf("failed to split bulk request, failed to close gzip writer: %w", err)
+		}
+	}
+
+	var (
+		result []*BulkIndexer
+		currBi *BulkIndexer
+	)
+
+	// The below logic calculates the size of the new data being added without
+	// considering compression. Considering the max size would generally be >>>
+	// single data size, the difference should be acceptable for practical cases.
+	//
+	// TODO(lahsivjar): Benchmark+optimize
+	var reader *bufio.Reader
+	if b.config.CompressionLevel != gzip.NoCompression {
+		gzipReader, err := gzip.NewReader(&b.buf)
+		if err != nil {
+			return nil, fmt.Errorf("failed to split bulk requests, failed to read compressed data: %w", err)
+		}
+		defer gzipReader.Close()
+		reader = bufio.NewReader(gzipReader)
+	} else {
+		reader = bufio.NewReader(&b.buf)
+	}
+	var tmpBuffer bytes.Buffer
+	for {
+		meta, err := reader.ReadSlice('\n')
+		if err != nil {
+			if err == io.EOF {
+				// EOF reached, metadata should not cause EOF so we can safely discard any read data here
+				break
+			}
+			return nil, fmt.Errorf("failed to split bulk requests, failed to read metadata: %w, %v", err, meta)
+		}
+		_, err = tmpBuffer.Write(meta)
+		if err != nil {
+			return nil, fmt.Errorf("failed to split bulk requests, failed to write metadata: %w", err)
+		}
+
+		data, err := reader.ReadSlice('\n')
+		if err != nil {
+			return nil, fmt.Errorf("failed to split bulk requests, failed to read item: %w", err)
+		}
+		_, err = tmpBuffer.Write(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to split bulk requests, failed to write item: %w", err)
+		}
+
+		newDataSize := getSizeForByteBuffer(tmpBuffer, sizerType)
+		if newDataSize > maxSize {
+			return nil, errors.New("failed to split bulk request buffer, smallest bulk is greater than configured max size")
+		}
+
+		// compression is not considered for calculating the size of the data
+		// to be added to the new bulk indexer
+		if currBi == nil || currBi.Size(sizerType)+newDataSize > maxSize {
+			currBi = newBulkIndexer(b.config)
+			result = append(result, currBi)
+		}
+
+		if _, err := io.Copy(currBi.writer, &tmpBuffer); err != nil {
+			return nil, fmt.Errorf("failed to split bulk requests aa: %w", err)
+		}
+		currBi.itemsAdded++
+		tmpBuffer.Reset()
+	}
+	return result, nil
 }
 
 func (b *BulkIndexer) newBulkIndexRequest(ctx context.Context) (*http.Request, error) {
@@ -738,4 +875,20 @@ func (e ErrorFlushFailed) ResponseBody() string {
 
 func (e ErrorFlushFailed) Error() string {
 	return fmt.Sprintf("flush failed (%d): %s", e.statusCode, e.resp)
+}
+
+type SizerType int
+
+const (
+	ItemsCountSizer SizerType = iota
+	UncompressedBytesSizer
+	CompressedBytesSizer
+)
+
+func getSizeForByteBuffer(b bytes.Buffer, sizerType SizerType) int {
+	if sizerType == ItemsCountSizer {
+		return 1
+	}
+	// Compression is not considered
+	return b.Len()
 }

--- a/bulk_indexer_test.go
+++ b/bulk_indexer_test.go
@@ -175,6 +175,194 @@ func TestBulkIndexer(t *testing.T) {
 	}
 }
 
+func TestBulkIndexer_Merge(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+
+		sourceCompressionLevel int
+		sourceIndexerItems     int
+
+		targetCompressionLevel int
+		targetIndexerItems     int
+
+		expectedErr string
+	}{
+		{
+			name:                   "src_target_empty",
+			sourceCompressionLevel: gzip.NoCompression,
+			sourceIndexerItems:     0,
+			targetCompressionLevel: gzip.NoCompression,
+			targetIndexerItems:     0,
+		},
+		{
+			name:                   "src_empty",
+			sourceCompressionLevel: gzip.NoCompression,
+			sourceIndexerItems:     0,
+			targetCompressionLevel: gzip.NoCompression,
+			targetIndexerItems:     100,
+		},
+		{
+			name:                   "target_empty",
+			sourceCompressionLevel: gzip.NoCompression,
+			sourceIndexerItems:     100,
+			targetCompressionLevel: gzip.NoCompression,
+			targetIndexerItems:     0,
+		},
+		{
+			name:                   "merge_with_both_data",
+			sourceCompressionLevel: gzip.NoCompression,
+			sourceIndexerItems:     100,
+			targetCompressionLevel: gzip.NoCompression,
+			targetIndexerItems:     20,
+		},
+		{
+			name:                   "compressed",
+			sourceCompressionLevel: gzip.BestCompression,
+			sourceIndexerItems:     100,
+			targetCompressionLevel: gzip.BestCompression,
+			targetIndexerItems:     20,
+		},
+		{
+			name:                   "different_compression",
+			sourceCompressionLevel: gzip.BestCompression,
+			sourceIndexerItems:     100,
+			targetCompressionLevel: gzip.BestSpeed,
+			targetIndexerItems:     20,
+			expectedErr:            "only same compression level merge is supported",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := docappendertest.NewMockElasticsearchClient(t, func(w http.ResponseWriter, r *http.Request) {
+				_, result, _ := docappendertest.DecodeBulkRequestWithStats(r)
+				json.NewEncoder(w).Encode(result)
+			})
+			sourceIndexer, err := docappender.NewBulkIndexer(docappender.BulkIndexerConfig{
+				Client:             client,
+				MaxDocumentRetries: 100_000, // disable retry
+				CompressionLevel:   tc.sourceCompressionLevel,
+			})
+			require.NoError(t, err)
+			targetIndexer, err := docappender.NewBulkIndexer(docappender.BulkIndexerConfig{
+				Client:             client,
+				MaxDocumentRetries: 100_000, // disable retry
+				CompressionLevel:   tc.targetCompressionLevel,
+			})
+			require.NoError(t, err)
+			generateLoad := func(items int, indexer *docappender.BulkIndexer) {
+				for indexer.Items() != items {
+					require.NoError(t, indexer.Add(docappender.BulkIndexerItem{
+						Index: "testidx",
+						Body: newJSONReader(map[string]any{
+							"@timestamp": time.Now().Format(docappendertest.TimestampFormat),
+						}),
+					}))
+				}
+			}
+
+			generateLoad(tc.sourceIndexerItems, sourceIndexer)
+			generateLoad(tc.targetIndexerItems, targetIndexer)
+
+			totalItems := tc.sourceIndexerItems + tc.targetIndexerItems
+			err = targetIndexer.Merge(sourceIndexer)
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+				assert.Equal(t, totalItems, targetIndexer.Items())
+				stat, err := targetIndexer.Flush(context.Background())
+				require.NoError(t, err)
+				assert.Equal(t, totalItems, int(stat.Indexed))
+			} else {
+				require.ErrorContains(t, err, tc.expectedErr)
+			}
+		})
+	}
+}
+
+func TestBulkIndexer_Split(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+
+		sourceIndexerMinSize   int // used to populate test data
+		sourceCompressionLevel int
+
+		maxSize   int
+		sizerType docappender.SizerType
+
+		expectedErr string
+	}{
+		{
+			name:                   "empty",
+			maxSize:                10,
+			sizerType:              docappender.ItemsCountSizer,
+			sourceIndexerMinSize:   0,
+			sourceCompressionLevel: gzip.BestCompression,
+		},
+		{
+			name:                   "uncompressed_items_split",
+			maxSize:                100,
+			sizerType:              docappender.ItemsCountSizer,
+			sourceIndexerMinSize:   205,
+			sourceCompressionLevel: gzip.NoCompression,
+		},
+		{
+			name:                   "uncompressed_bytes_split",
+			maxSize:                10_000,
+			sizerType:              docappender.UncompressedBytesSizer,
+			sourceIndexerMinSize:   1_000_005,
+			sourceCompressionLevel: gzip.NoCompression,
+		},
+		{
+			name:                   "compressed_items_split",
+			maxSize:                100,
+			sizerType:              docappender.ItemsCountSizer,
+			sourceIndexerMinSize:   205,
+			sourceCompressionLevel: gzip.BestCompression,
+		},
+		{
+			name:                   "compressed_bytes_split",
+			maxSize:                10_000,
+			sizerType:              docappender.CompressedBytesSizer,
+			sourceIndexerMinSize:   1_000_005,
+			sourceCompressionLevel: gzip.BestCompression,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := docappendertest.NewMockElasticsearchClient(t, func(w http.ResponseWriter, r *http.Request) {
+				_, result, _ := docappendertest.DecodeBulkRequestWithStats(r)
+				json.NewEncoder(w).Encode(result)
+			})
+			indexer, err := docappender.NewBulkIndexer(docappender.BulkIndexerConfig{
+				Client:             client,
+				MaxDocumentRetries: 100_000, // disable retry
+				CompressionLevel:   tc.sourceCompressionLevel,
+			})
+			require.NoError(t, err)
+
+			// Populate the required indexer to size
+			for indexer.Size(tc.sizerType) < tc.sourceIndexerMinSize {
+				require.NoError(t, indexer.Add(docappender.BulkIndexerItem{
+					Index: "testidx",
+					Body: newJSONReader(map[string]any{
+						"@timestamp": time.Now().Format(docappendertest.TimestampFormat),
+					}),
+				}))
+			}
+			totalItems := indexer.Items()
+
+			splitBulkIndexers, err := indexer.Split(tc.maxSize, tc.sizerType)
+			require.NoError(t, err)
+
+			var indexedItems int
+			for _, bi := range splitBulkIndexers {
+				stat, err := bi.Flush(context.Background())
+				require.NoError(t, err)
+				assert.LessOrEqual(t, bi.Size(tc.sizerType), tc.maxSize)
+				indexedItems += int(stat.Indexed)
+			}
+			assert.Equal(t, totalItems, indexedItems)
+		})
+	}
+}
+
 func TestDynamicTemplates(t *testing.T) {
 	client := docappendertest.NewMockElasticsearchClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, result, _, dynamicTemplates := docappendertest.DecodeBulkRequestWithStatsAndDynamicTemplates(r)

--- a/docappendertest/docappendertest.go
+++ b/docappendertest/docappendertest.go
@@ -96,7 +96,8 @@ func DecodeBulkRequest(r *http.Request) ([][]byte, BulkIndexerResponse) {
 func DecodeBulkRequestWithStats(r *http.Request) (
 	docs [][]byte,
 	res BulkIndexerResponse,
-	stats RequestStats) {
+	stats RequestStats,
+) {
 	indexed, result, stats, _ := DecodeBulkRequestWithStatsAndDynamicTemplates(r)
 	return indexed, result, stats
 }
@@ -119,8 +120,8 @@ func DecodeBulkRequestWithStatsAndDynamicTemplates(r *http.Request) (
 	docs [][]byte,
 	res BulkIndexerResponse,
 	stats RequestStats,
-	dynamicTemplates []map[string]string) {
-
+	dynamicTemplates []map[string]string,
+) {
 	indexed, result, stats, dynamicTemplates, _ := DecodeBulkRequestWithStatsAndDynamicTemplatesAndPipelines(r)
 	return indexed, result, stats, dynamicTemplates
 }


### PR DESCRIPTION
The merge and split APIs will allow Elasticsearch exporter to size the requests to ES using the new batch queue based on the bulk request sizes.