### PR TITLE
Eagerly seed counters and up/down counters with Add(0)

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -129,6 +129,32 @@ func New(client elastictransport.Interface, cfg Config) (*Appender, error) {
 	indexer.id = fmt.Sprintf("%p", indexer)
 	indexer.pool.Register(indexer.id)
 	indexer.metrics.availableBulkRequests.Add(context.Background(), int64(cfg.MaxRequests), indexer.metricAttributeSet)
+	// Eagerly seed every counter and up/down counter that only carries the
+	// indexer's MetricAttributes with a zero data point, so the SDK exports
+	// the metric from process start. Cumulative counters are implicitly 0
+	// before any Add, so this is a no-op semantically while making the
+	// metric visible to consumers that infer schema from a snapshot
+	// (e.g. apm-server's /stats endpoint).
+	//
+	// docsIndexed (elasticsearch.events.processed) and docsRetried
+	// (elasticsearch.events.retried) carry additional per-call attributes
+	// (status, greatest_retry) and are intentionally not seeded here:
+	// emitting an attribute-less zero data point would violate the
+	// existing contract that every data point on those streams carries
+	// those attributes.
+	for _, c := range []interface{ Add(context.Context, int64, ...metric.AddOption) }{
+		indexer.metrics.bulkRequests,
+		indexer.metrics.docsAdded,
+		indexer.metrics.docsActive,
+		indexer.metrics.bytesTotal,
+		indexer.metrics.bytesUncompressedTotal,
+		indexer.metrics.inflightBulkrequests,
+		indexer.metrics.activeCreated,
+		indexer.metrics.activeDestroyed,
+		indexer.metrics.blockedAdd,
+	} {
+		c.Add(context.Background(), 0, indexer.metricAttributeSet)
+	}
 	// We create a cancellable context for the errgroup.Group for unblocking
 	// flushes when Close returns. We intentionally do not use errgroup.WithContext,
 	// because one flush failure should not cause the context to be cancelled.

--- a/appender_test.go
+++ b/appender_test.go
@@ -221,10 +221,6 @@ func TestAppenderWithFailureStore(t *testing.T) {
 			assertProcessedCounter(m, indexerAttrs)
 		case "elasticsearch.bulk_requests.available":
 			assertCounter(m, 0, indexerAttrs)
-		case "elasticsearch.indexer.created":
-			assertCounter(m, 1, indexerAttrs)
-		case "elasticsearch.indexer.destroyed":
-			assertCounter(m, 1, indexerAttrs)
 		case "elasticsearch.flushed.bytes":
 			assertCounter(m, bytesTotal, indexerAttrs)
 		case "elasticsearch.flushed.uncompressed.bytes":
@@ -232,8 +228,13 @@ func TestAppenderWithFailureStore(t *testing.T) {
 		case "elasticsearch.buffer.latency", "elasticsearch.flushed.latency":
 			// expect this metric name but no assertions done
 			// as it's histogram and it's checked elsewhere
-		case "elasticsearch.bulk_requests.inflight":
-			// Concurrent bulk requests are observed, but ignored.
+		case "elasticsearch.bulk_requests.inflight",
+			"elasticsearch.indexer.created",
+			"elasticsearch.indexer.destroyed",
+			"docappender.blocked.add":
+			// expect this metric name but no assertions done;
+			// emitted at zero by the eager Add(0) in New(), and
+			// the corresponding feature is not exercised here.
 		default:
 			unexpectedMetrics = append(unexpectedMetrics, m.Name)
 		}
@@ -388,8 +389,13 @@ func TestAppenderRetryTooMany(t *testing.T) {
 		case "elasticsearch.buffer.latency", "elasticsearch.flushed.latency":
 			// expect this metric name but no assertions done
 			// as it's histogram and it's checked elsewhere
-		case "elasticsearch.bulk_requests.inflight":
-			// Concurrent bulk requests are observed, but ignored.
+		case "elasticsearch.bulk_requests.inflight",
+			"elasticsearch.indexer.created",
+			"elasticsearch.indexer.destroyed",
+			"docappender.blocked.add":
+			// expect this metric name but no assertions done;
+			// emitted at zero by the eager Add(0) in New(), and
+			// the corresponding feature is not exercised here.
 		default:
 			unexpectedMetrics = append(unexpectedMetrics, m.Name)
 		}
@@ -516,9 +522,12 @@ func TestAppenderAvailableAppenders(t *testing.T) {
 				assert.Equal(t, int64(N), dp.Value)
 			}
 		case "elasticsearch.bulk_requests.count":
+			// Flushes are in flight but blocked at the mock client; the
+			// count is incremented in a defer after flush returns, so it
+			// stays at the eager-init zero value at this collection point.
 			counter := m.Data.(metricdata.Sum[int64])
 			for _, dp := range counter.DataPoints {
-				assert.Equal(t, int64(N), dp.Value)
+				assert.Equal(t, int64(0), dp.Value)
 			}
 		case "elasticsearch.bulk_requests.available":
 			counter := m.Data.(metricdata.Sum[int64])


### PR DESCRIPTION
## Summary

Cumulative counters and up/down counters are implicitly `0` before any `Add`, but the OTel SDK only exports a metric stream once it has at least one data point. Consumers that derive schema from a single export snapshot — apm-server's `/stats` endpoint, which feeds upstream Beats / Elasticsearch / Integrations mapping regeneration — silently miss every counter that has not yet been incremented at snapshot time.

This PR seeds every counter and up/down counter that only carries the indexer's `MetricAttributes` with `Add(0, metricAttributeSet)` immediately after `New()` builds `metricAttributeSet`. Cumulative aggregation merges these zeros with any subsequent `Add` at the same attribute set, so observed values are unchanged.

## Why this layer

The instrument-creation site is the layer that owns name + kind + unit + description + attribute identity, so eager init here doesn't require any consumer to mirror that identity (which would be brittle). Any future docappender user gets the same eager-export property for free.

## What is intentionally not seeded

- `docsIndexed` (`elasticsearch.events.processed`) — carries a `status` attribute on every real `Add`. An attribute-less zero data point would violate the existing test contract that every data point on this stream has a `status` attribute, and seeding per-status would require enumerating the status set at registration time.
- `docsRetried` (`elasticsearch.events.retried`) — same shape, with a `greatest_retry` attribute.

A follow-up could address those two streams (e.g. by seeding per known status), but it is out of scope here.

## Test changes

Three tests had `case` arms that previously never fired because the relevant metric was absent from the snapshot. With eager init those cases fire, so each test needs a deliberate stance on the new arms:

- **`TestAppenderWithFailureStore`** — `elasticsearch.indexer.{created,destroyed}` and `docappender.blocked.add` are now folded into the existing "expect this metric name but no assertions done" `case` block (alongside `bulk_requests.inflight`). The test does not exercise scaling or input-blocking, so asserting a zero value here would over-claim what the test verifies. The original `assertCounter(m, 1, ...)` arms (which were unreachable, hence never exercised) are removed; `asserted.Load()` count is preserved at `7`.
- **`TestAppenderRetryTooMany`** — same shape: the three new arms fold into the no-assertion list. `asserted.Load()` stays at `8`.
- **`TestAppenderAvailableAppenders`** — `elasticsearch.bulk_requests.count` arm is updated from `int64(N)` to `int64(0)` with an explanatory comment. The test deliberately blocks every flush at the mock client, and `bulkRequests.Add(1)` is in a `defer` after `flush()` returns, so 0 is the meaningful, observed outcome of the test (not just an eager-init artefact). The original `int64(N)` was unreachable.

No production-path metric values change.

## Test plan

- [x] `go test ./...` passes locally.
- [ ] Reviewer confirms the test stance is correct (no-assertion for features the test doesn't exercise; explicit `0` only where the test deliberately produces 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
